### PR TITLE
remove __eth__ from lido's parser

### DIFF
--- a/ethereum/lido/parsers.json
+++ b/ethereum/lido/parsers.json
@@ -46,7 +46,7 @@
                             "value": {
                                 "quantity": {
                                     "path": {
-                                        "transaction": "__eth__.amount"
+                                        "transaction": "amount"
                                     }
                                 },
                                 "token": {


### PR DESCRIPTION
### What is it about ? 

- The __eth__ for a transaction amount is useful to understand where it comes from but it add a lot of complexity for Firmware team 