### PR TITLE
Remove transaction when amount in payload

### DIFF
--- a/ethereum/paraswap/parsers.json
+++ b/ethereum/paraswap/parsers.json
@@ -15,8 +15,7 @@
                             "value": {
                                 "quantity": {
                                     "path": {
-                                        "default": "amountIn",
-                                        "transaction": "amount"
+                                        "default": "amountIn"
                                     }
                                 },
                                 "token": {
@@ -64,14 +63,12 @@
                             "value": {
                                 "quantity": {
                                     "path": {
-                                        "default": "data.fromAmount",
-                                        "transaction": "amount"
+                                        "default": "data.fromAmount"
                                     }
                                 },
                                 "token": {
                                     "path": {
-                                        "default": "data.fromToken",
-                                        "transaction": "amount"
+                                        "default": "data.fromToken"
                                     }
                                 },
                                 "type": "amount"

--- a/ethereum/uniswap/parsers.json
+++ b/ethereum/uniswap/parsers.json
@@ -15,7 +15,7 @@
                             "value": {
                                 "quantity": {
                                     "path": {
-                                        "default": "amountOutMin"
+                                        "transaction": "amount"
                                     }
                                 },
                                 "token": {

--- a/ethereum/uniswap/parsers.json
+++ b/ethereum/uniswap/parsers.json
@@ -15,8 +15,7 @@
                             "value": {
                                 "quantity": {
                                     "path": {
-                                        "default": "amountOutMin",
-                                        "transaction": "amount"
+                                        "default": "amountOutMin"
                                     }
                                 },
                                 "token": {
@@ -32,8 +31,7 @@
                             "value": {
                                 "quantity": {
                                     "path": {
-                                        "default": "amountOutMin",
-                                        "transaction": "amount"
+                                        "default": "amountOutMin"
                                     }
                                 },
                                 "token": {


### PR DESCRIPTION
#### What is it about ? 

- When eth is considered in the transaction (i.e. a swap) the value is not only in the transaction but also in the payload
- We can only consider the one in the payload