### PR TITLE
add ethContractAddress to methods

### DIFF
--- a/ethereum/paraswap/parsers.json
+++ b/ethereum/paraswap/parsers.json
@@ -170,7 +170,9 @@
                     "functionType": "swap",
                     "label": "Swap",
                     "name": "simpleSwap",
-                    "options": {},
+                    "options": {
+                        "ethContractAddress": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+                    },
                     "selector": "0xcfc0afeb"
                 },
                 {
@@ -215,7 +217,9 @@
                     "functionType": "swap",
                     "label": "Swap",
                     "name": "swapOnUniswap",
-                    "options": {},
+                    "options": {
+                        "ethContractAddress": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+                    },
                     "selector": "0x58b9d179"
                 },
                 {
@@ -260,7 +264,9 @@
                     "functionType": "swap",
                     "label": "Swap",
                     "name": "multiSwap",
-                    "options": {},
+                    "options": {
+                        "ethContractAddress": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+                    },
                     "selector": "0x8f00eccb"
                 },
                 {
@@ -305,7 +311,9 @@
                     "functionType": "swap",
                     "label": "Swap",
                     "name": "buyOnUniswap",
-                    "options": {},
+                    "options": {
+                        "ethContractAddress": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+                    },
                     "selector": "0xf9355f72"
                 },
                 {
@@ -350,7 +358,9 @@
                     "functionType": "swap",
                     "label": "Swap",
                     "name": "buyOnUniswapFork",
-                    "options": {},
+                    "options": {
+                        "ethContractAddress": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+                    },
                     "selector": "0x33635226"
                 },
                 {
@@ -395,7 +405,9 @@
                     "functionType": "swap",
                     "label": "Swap",
                     "name": "buy",
-                    "options": {},
+                    "options": {
+                        "ethContractAddress": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+                    },
                     "selector": "0xf95a49eb"
                 }
             ]


### PR DESCRIPTION
#### What is it about ? 

- Paraswap has some edge cases when interacting with ethereum. Eth is represented as a token with 0xeeeeeee as an address. Parsers need to hold this information to ease the work of FW team.

https://ledgerhq.atlassian.net/wiki/spaces/TA/pages/3600023571/ARCH+SCI+Handling+Paraswap+special+cases