### PR TITLE
Add option ethContractAddress to lido

### DIFF
--- a/ethereum/lido/parsers.json
+++ b/ethereum/lido/parsers.json
@@ -97,7 +97,9 @@
                     "functionType": "stake",
                     "label": "Stake ETH",
                     "name": "submit",
-                    "options": {},
+                    "options": {
+                        "ethContractAddress": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
+                    },
                     "selector": "0xa1903eab"
                 }
             ]


### PR DESCRIPTION
We are addind a default token value for the submit method of lido. Hence we need and option to spot it.