### PR TITLE
[VG-9445] Remove temporarly data from safeTransferFrom

### DIFF
--- a/ethereum/nft/parsers.json
+++ b/ethereum/nft/parsers.json
@@ -100,17 +100,6 @@
                                     }
                                 }
                             }
-                        },
-                        {
-                            "format": "raw",
-                            "name": "data",
-                            "value": {
-                                "uint256": {
-                                    "path": {
-                                        "default": "data"
-                                    }
-                                }
-                            }
                         }
                     ],
                     "functionName": "safeTransferFrom",
@@ -133,10 +122,6 @@
                         {
                             "label": "Token ID",
                             "name": "tokenID"
-                        },
-                        {
-                            "label": "Data",
-                            "name": "data"
                         }
                     ],
                     "selector": "0xb88d4fde"


### PR DESCRIPTION
# What is it about ? 

The arguments data is in bytes; not yet supported. 
Development time would be too long for an arguments that product don't estimate that much important.