### PR TITLE
feature: Add validators on parser files

### DIFF
--- a/scripts/validate_files.py
+++ b/scripts/validate_files.py
@@ -12,7 +12,8 @@ from validation.validators import (
     format_validator,
     missing_abi_validator,
     run_validations,
-    schema_validator, unique_field_validator,
+    schema_validator, unique_field_validator, contract_matching_validator, missing_schema_validator,
+    eip55_address_validator,
 )
 
 logging.basicConfig(level="INFO")
@@ -44,6 +45,10 @@ VALIDATORS = {
     "unique_id": ("./*/**/parsers.json", unique_field_validator(["id"])),
     "parsers_abi_not_missing": ("./*/**/parsers.json", missing_abi_validator),
     "b2c_abi_not_missing": ("./*/**/b2c.json", missing_abi_validator),
+    "parsers_schema_not_missing": ("./*/**/parsers.json", missing_schema_validator()),
+    "b2c_schema_not_missing": ("./*/**/b2c.json", missing_schema_validator()),
+    "eip55_parser": ("./*/**/parsers.json", eip55_address_validator),
+    "contract_matching": ("./*/**/parsers.json", contract_matching_validator),
     **SCHEMA_VALIDATORS,
 }
 

--- a/scripts/validate_files.py
+++ b/scripts/validate_files.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Callable, Iterable, Tuple
 
 from jsonschema.exceptions import ValidationError
+
 from validation.validators import (
     abi_filename_validator,
     eip712_schema_validator,
@@ -12,7 +13,10 @@ from validation.validators import (
     format_validator,
     missing_abi_validator,
     run_validations,
-    schema_validator, unique_field_validator, contract_matching_validator, missing_schema_validator,
+    schema_validator,
+    unique_field_validator,
+    contract_matching_validator,
+    missing_schema_validator,
     eip55_address_validator,
 )
 
@@ -36,7 +40,6 @@ SCHEMA_VALIDATORS = {
     for validator_name, validator in schema_validator_generator()
 }
 
-
 VALIDATORS = {
     "json": ("./*/**/*.json", format_validator),
     "endlines": ("./*/**/*.json", endlines_validator),
@@ -51,7 +54,6 @@ VALIDATORS = {
     "contract_matching": ("./*/**/parsers.json", contract_matching_validator),
     **SCHEMA_VALIDATORS,
 }
-
 
 if __name__ == "__main__":
     failed = False

--- a/scripts/validation/validators.py
+++ b/scripts/validation/validators.py
@@ -7,6 +7,7 @@ from json.decoder import JSONDecodeError
 from pathlib import Path
 from typing import Callable, Tuple, List
 
+from eth_utils import to_checksum_address, is_checksum_address
 from jsonschema import ValidationError
 from jsonschema.validators import validator_for
 
@@ -77,8 +78,8 @@ def unique_field_validator(
             for field_name in field_names
             if field_name in json_data
         )
-        blockchain = Path(filename).parts[0]
-        identifier = f"{blockchain}/{field_value}".lower()
+        coin_name = Path(filename).parts[0]
+        identifier = f"{coin_name}/{field_value}".lower()
 
         if identifier in unique:
             logger.info(
@@ -134,6 +135,25 @@ def eip712_schema_validator(data: str, filename: str) -> Tuple[bool, str]:
     return True, ""
 
 
+def missing_schema_validator():
+    coins = set()
+
+    def _inner_validator(data: str, filename: str) -> Tuple[bool, str]:
+        parser_path = Path(filename)
+        coin_name = parser_path.parts[0]
+        if coin_name in coins:
+            return True, ""
+        coins.add(coin_name)
+        target_name = parser_path.name.removesuffix(".json")
+        schema_path = parser_path.parent.parent / f"{target_name}.schema.json"
+        if schema_path.exists():
+            return True, ""
+        else:
+            return False, f"Missing schema {schema_path}"
+
+    return _inner_validator
+
+
 def missing_abi_validator(data: str, filename: str) -> Tuple[bool, str]:
     try:
         dapp_addresses = set(
@@ -160,3 +180,39 @@ def abi_filename_validator(data: str, filename: str) -> Tuple[bool, str]:
         return True, ""
     else:
         return False, f"ABI filename is not matching {lowercase_address_regex}"
+
+
+def eip55_address_validator(data: str, filename: str) -> Tuple[bool, str]:
+    error = False
+    try:
+        json_data = json.loads(data)
+    except JSONDecodeError as err:
+        logger.debug("\tinvalid: File %s is not a valid json", filename, exc_info=True)
+        return False, str(err)
+
+    for contract in json_data.get("contracts", []):
+        # Address respects EIP55 format
+        address = contract.get("address", "")
+        expected = to_checksum_address(address)
+        is_valid = address == expected
+        if not is_valid:
+            error = True
+            logger.info(
+                "\tinvalid: Contract address %s not in eip55 format",
+                address,
+            )
+            contract["address"] = expected
+    if error:
+        formatted = json.dumps(json_data, indent=4, sort_keys=True, ensure_ascii=False)
+        with open(filename, "w") as f:
+            f.write(formatted)
+        return False, "Some addresses not correctly formatted, fixing..."
+
+    return True, ""
+
+
+def contract_matching_validator(data: str, filename: str) -> Tuple[bool, str]:
+    # function name in ABI
+    # function signature in ABI
+    return True, ""
+


### PR DESCRIPTION
Add the following validators to quickly invalidate parser files:
- presence of parser validation schema
- unicity of parser IDs on a given blockchain
- contract addresses correctly formatted with EIP55
- function mapping between parser and ABI
- arguments mapping between a function and its screen