### PR TITLE
Fix duplicate contracts

### DIFF
--- a/ethereum_goerli/[ L ] Market/b2c.json
+++ b/ethereum_goerli/[ L ] Market/b2c.json
@@ -163,7 +163,7 @@
             }
         },
         {
-            "address": "0xe506ed52bdb3cff38772ebef8340621f5147eaad",
+            "address": "0x16fe8822d358a3f6ad52dd060cdec409e4b6d409",
             "contractName": "Stable MultiMint NFT",
             "selectors": {
                 "0x11413601": {


### PR DESCRIPTION
MultiMintSign (erc721) && Inspiredy By Ledger (1155) contract were with the same contract address. 
This is a fix for the 721 with the correct address 0x16fe8822d358a3f6ad52dd060cdec409e4b6d409