### PR TITLE
Libertify/update prod proxies

### DIFF
--- a/arbitrum/libertify/abis/0x833a41f86a87e3ff87c7577b2a79634e580e8a4b.abi.json
+++ b/arbitrum/libertify/abis/0x833a41f86a87e3ff87c7577b2a79634e580e8a4b.abi.json
@@ -1,0 +1,297 @@
+[
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_wethAddr",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "inputs": [],
+        "name": "BadConstructor",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "BadReceiver",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "BadReturn",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "BadSwap",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "BadSymbol",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "BadToken",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "BadValue",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "UnevenSwap",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountIn",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "srcToken",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "vaultAddr",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "data",
+                "type": "bytes[]"
+            }
+        ],
+        "name": "deposit",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountIn",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "srcToken",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "vaultAddr",
+                "type": "address"
+            },
+            {
+                "internalType": "string",
+                "name": "vaultSymbol",
+                "type": "string"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "data",
+                "type": "bytes[]"
+            }
+        ],
+        "name": "depositWithSymbolCheck",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountIn",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "vaultAddr",
+                "type": "address"
+            }
+        ],
+        "name": "previewWithdraw",
+        "outputs": [
+            {
+                "internalType": "address[]",
+                "name": "tokens",
+                "type": "address[]"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "amountsOut",
+                "type": "uint256[]"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountIn",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "dstToken",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "vaultAddr",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "minAmountOut",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "data",
+                "type": "bytes[]"
+            },
+            {
+                "internalType": "uint256",
+                "name": "deadline",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint8",
+                "name": "v",
+                "type": "uint8"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "r",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "s",
+                "type": "bytes32"
+            }
+        ],
+        "name": "withdraw",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountIn",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "dstToken",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "vaultAddr",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "minAmountOut",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "data",
+                "type": "bytes[]"
+            }
+        ],
+        "name": "withdraw",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountOut",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountIn",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "dstToken",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "vaultAddr",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "minAmountOut",
+                "type": "uint256"
+            },
+            {
+                "internalType": "string",
+                "name": "vaultSymbol",
+                "type": "string"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "data",
+                "type": "bytes[]"
+            }
+        ],
+        "name": "withdrawWithSymbolCheck",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    }
+]

--- a/arbitrum/libertify/b2c.json
+++ b/arbitrum/libertify/b2c.json
@@ -1,0 +1,27 @@
+{
+    "blockchainName": "arbitrum",
+    "chainId": 42161,
+    "contracts": [
+        {
+            "address": "0x833a41f86a87e3ff87c7577b2a79634e580e8a4b",
+            "contractName": "LibertiV2Proxy",
+            "selectors": {
+                "0xa2922622": {
+                    "erc20OfInterest": [
+                        "dstToken"
+                    ],
+                    "method": "withdrawWithSymbolCheck",
+                    "plugin": "libertify"
+                },
+                "0xaa2daba6": {
+                    "erc20OfInterest": [
+                        "srcToken"
+                    ],
+                    "method": "depositWithSymbolCheck",
+                    "plugin": "libertify"
+                }
+            }
+        }
+    ],
+    "name": "libertify"
+}

--- a/ethereum/libertify/abis/0x54ef1e41a5ebfa1f84b116c0ae2417e2a7344d0f.abi.json
+++ b/ethereum/libertify/abis/0x54ef1e41a5ebfa1f84b116c0ae2417e2a7344d0f.abi.json
@@ -1,0 +1,297 @@
+[
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_wethAddr",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "inputs": [],
+        "name": "BadConstructor",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "BadReceiver",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "BadReturn",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "BadSwap",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "BadSymbol",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "BadToken",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "BadValue",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "UnevenSwap",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountIn",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "srcToken",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "vaultAddr",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "data",
+                "type": "bytes[]"
+            }
+        ],
+        "name": "deposit",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountIn",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "srcToken",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "vaultAddr",
+                "type": "address"
+            },
+            {
+                "internalType": "string",
+                "name": "vaultSymbol",
+                "type": "string"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "data",
+                "type": "bytes[]"
+            }
+        ],
+        "name": "depositWithSymbolCheck",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountIn",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "vaultAddr",
+                "type": "address"
+            }
+        ],
+        "name": "previewWithdraw",
+        "outputs": [
+            {
+                "internalType": "address[]",
+                "name": "tokens",
+                "type": "address[]"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "amountsOut",
+                "type": "uint256[]"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountIn",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "dstToken",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "vaultAddr",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "minAmountOut",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "data",
+                "type": "bytes[]"
+            },
+            {
+                "internalType": "uint256",
+                "name": "deadline",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint8",
+                "name": "v",
+                "type": "uint8"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "r",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "s",
+                "type": "bytes32"
+            }
+        ],
+        "name": "withdraw",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountIn",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "dstToken",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "vaultAddr",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "minAmountOut",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "data",
+                "type": "bytes[]"
+            }
+        ],
+        "name": "withdraw",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountOut",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountIn",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "dstToken",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "vaultAddr",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "minAmountOut",
+                "type": "uint256"
+            },
+            {
+                "internalType": "string",
+                "name": "vaultSymbol",
+                "type": "string"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "data",
+                "type": "bytes[]"
+            }
+        ],
+        "name": "withdrawWithSymbolCheck",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    }
+]

--- a/ethereum/libertify/b2c.json
+++ b/ethereum/libertify/b2c.json
@@ -21,6 +21,26 @@
                     "plugin": "libertify"
                 }
             }
+        },
+        {
+            "address": "0x54ef1e41a5ebfa1f84b116c0ae2417e2a7344d0f",
+            "contractName": "LibertiV2Proxy",
+            "selectors": {
+                "0xa2922622": {
+                    "erc20OfInterest": [
+                        "dstToken"
+                    ],
+                    "method": "withdrawWithSymbolCheck",
+                    "plugin": "libertify"
+                },
+                "0xaa2daba6": {
+                    "erc20OfInterest": [
+                        "srcToken"
+                    ],
+                    "method": "depositWithSymbolCheck",
+                    "plugin": "libertify"
+                }
+            }
         }
     ],
     "name": "libertify"

--- a/polygon/libertify/abis/0x77c075c1de9b61e0c30de095febf67841d4d9ff8.abi.json
+++ b/polygon/libertify/abis/0x77c075c1de9b61e0c30de095febf67841d4d9ff8.abi.json
@@ -1,0 +1,297 @@
+[
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_wethAddr",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "inputs": [],
+        "name": "BadConstructor",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "BadReceiver",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "BadReturn",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "BadSwap",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "BadSymbol",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "BadToken",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "BadValue",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "UnevenSwap",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountIn",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "srcToken",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "vaultAddr",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "data",
+                "type": "bytes[]"
+            }
+        ],
+        "name": "deposit",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountIn",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "srcToken",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "vaultAddr",
+                "type": "address"
+            },
+            {
+                "internalType": "string",
+                "name": "vaultSymbol",
+                "type": "string"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "data",
+                "type": "bytes[]"
+            }
+        ],
+        "name": "depositWithSymbolCheck",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountIn",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "vaultAddr",
+                "type": "address"
+            }
+        ],
+        "name": "previewWithdraw",
+        "outputs": [
+            {
+                "internalType": "address[]",
+                "name": "tokens",
+                "type": "address[]"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "amountsOut",
+                "type": "uint256[]"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountIn",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "dstToken",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "vaultAddr",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "minAmountOut",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "data",
+                "type": "bytes[]"
+            },
+            {
+                "internalType": "uint256",
+                "name": "deadline",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint8",
+                "name": "v",
+                "type": "uint8"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "r",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "s",
+                "type": "bytes32"
+            }
+        ],
+        "name": "withdraw",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountIn",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "dstToken",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "vaultAddr",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "minAmountOut",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "data",
+                "type": "bytes[]"
+            }
+        ],
+        "name": "withdraw",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountOut",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountIn",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "dstToken",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "vaultAddr",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "minAmountOut",
+                "type": "uint256"
+            },
+            {
+                "internalType": "string",
+                "name": "vaultSymbol",
+                "type": "string"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "data",
+                "type": "bytes[]"
+            }
+        ],
+        "name": "withdrawWithSymbolCheck",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    }
+]

--- a/polygon/libertify/b2c.json
+++ b/polygon/libertify/b2c.json
@@ -41,6 +41,26 @@
                     "plugin": "libertify"
                 }
             }
+        },
+        {
+            "address": "0x77c075c1de9b61e0c30de095febf67841d4d9ff8",
+            "contractName": "LibertiV2Proxy",
+            "selectors": {
+                "0xa2922622": {
+                    "erc20OfInterest": [
+                        "dstToken"
+                    ],
+                    "method": "withdrawWithSymbolCheck",
+                    "plugin": "libertify"
+                },
+                "0xaa2daba6": {
+                    "erc20OfInterest": [
+                        "srcToken"
+                    ],
+                    "method": "depositWithSymbolCheck",
+                    "plugin": "libertify"
+                }
+            }
         }
     ],
     "name": "libertify"


### PR DESCRIPTION
Include auxiliary contracts deployed in production on Ethereum, Arbitrum, and Polygon.