### PR TITLE
Add Uniswap `b2c.json` files for nano app external plugin

### DIFF
--- a/arbitrum/uniswap/abis/0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad.abi.json
+++ b/arbitrum/uniswap/abis/0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad.abi.json
@@ -1,0 +1,497 @@
+[
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "permit2",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "weth9",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "seaportV1_5",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "seaportV1_4",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "openseaConduit",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nftxZap",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "x2y2",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "foundation",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "sudoswap",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "elementMarket",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nft20Zap",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "cryptopunks",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "looksRareV2",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "routerRewardsDistributor",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "looksRareRewardsDistributor",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "looksRareToken",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "v2Factory",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "v3Factory",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "pairInitCodeHash",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "poolInitCodeHash",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct RouterParameters",
+                "name": "params",
+                "type": "tuple"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "inputs": [],
+        "name": "BalanceTooLow",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "BuyPunkFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ContractLocked",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ETHNotAccepted",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "commandIndex",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "message",
+                "type": "bytes"
+            }
+        ],
+        "name": "ExecutionFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "FromAddressIsNotOwner",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InsufficientETH",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InsufficientToken",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidBips",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "commandType",
+                "type": "uint256"
+            }
+        ],
+        "name": "InvalidCommandType",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidOwnerERC1155",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidOwnerERC721",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidPath",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidReserves",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidSpender",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "LengthMismatch",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "SliceOutOfBounds",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "TransactionDeadlinePassed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "UnableToClaim",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "UnsafeCast",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V2InvalidPath",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V2TooLittleReceived",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V2TooMuchRequested",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3InvalidAmountOut",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3InvalidCaller",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3InvalidSwap",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3TooLittleReceived",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3TooMuchRequested",
+        "type": "error"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "RewardsSent",
+        "type": "event"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "looksRareClaim",
+                "type": "bytes"
+            }
+        ],
+        "name": "collectRewards",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "commands",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "inputs",
+                "type": "bytes[]"
+            }
+        ],
+        "name": "execute",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "commands",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "inputs",
+                "type": "bytes[]"
+            },
+            {
+                "internalType": "uint256",
+                "name": "deadline",
+                "type": "uint256"
+            }
+        ],
+        "name": "execute",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "name": "onERC1155BatchReceived",
+        "outputs": [
+            {
+                "internalType": "bytes4",
+                "name": "",
+                "type": "bytes4"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "name": "onERC1155Received",
+        "outputs": [
+            {
+                "internalType": "bytes4",
+                "name": "",
+                "type": "bytes4"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "name": "onERC721Received",
+        "outputs": [
+            {
+                "internalType": "bytes4",
+                "name": "",
+                "type": "bytes4"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes4",
+                "name": "interfaceId",
+                "type": "bytes4"
+            }
+        ],
+        "name": "supportsInterface",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "int256",
+                "name": "amount0Delta",
+                "type": "int256"
+            },
+            {
+                "internalType": "int256",
+                "name": "amount1Delta",
+                "type": "int256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "uniswapV3SwapCallback",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "stateMutability": "payable",
+        "type": "receive"
+    }
+]

--- a/arbitrum/uniswap/b2c.json
+++ b/arbitrum/uniswap/b2c.json
@@ -1,0 +1,18 @@
+{
+    "blockchainName": "arbitrum",
+    "chainId": 42161,
+    "contracts": [
+        {
+            "address": "0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad",
+            "contractName": "UniversalRouter",
+            "selectors": {
+                "0x3593564c": {
+                    "erc20OfInterest": [],
+                    "method": "execute",
+                    "plugin": "Uniswap"
+                }
+            }
+        }
+    ],
+    "name": "Uniswap"
+}

--- a/avalanche/uniswap/abis/0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad.abi.json
+++ b/avalanche/uniswap/abis/0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad.abi.json
@@ -1,0 +1,497 @@
+[
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "permit2",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "weth9",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "seaportV1_5",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "seaportV1_4",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "openseaConduit",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nftxZap",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "x2y2",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "foundation",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "sudoswap",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "elementMarket",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nft20Zap",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "cryptopunks",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "looksRareV2",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "routerRewardsDistributor",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "looksRareRewardsDistributor",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "looksRareToken",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "v2Factory",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "v3Factory",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "pairInitCodeHash",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "poolInitCodeHash",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct RouterParameters",
+                "name": "params",
+                "type": "tuple"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "inputs": [],
+        "name": "BalanceTooLow",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "BuyPunkFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ContractLocked",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ETHNotAccepted",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "commandIndex",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "message",
+                "type": "bytes"
+            }
+        ],
+        "name": "ExecutionFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "FromAddressIsNotOwner",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InsufficientETH",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InsufficientToken",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidBips",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "commandType",
+                "type": "uint256"
+            }
+        ],
+        "name": "InvalidCommandType",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidOwnerERC1155",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidOwnerERC721",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidPath",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidReserves",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidSpender",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "LengthMismatch",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "SliceOutOfBounds",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "TransactionDeadlinePassed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "UnableToClaim",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "UnsafeCast",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V2InvalidPath",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V2TooLittleReceived",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V2TooMuchRequested",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3InvalidAmountOut",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3InvalidCaller",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3InvalidSwap",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3TooLittleReceived",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3TooMuchRequested",
+        "type": "error"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "RewardsSent",
+        "type": "event"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "looksRareClaim",
+                "type": "bytes"
+            }
+        ],
+        "name": "collectRewards",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "commands",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "inputs",
+                "type": "bytes[]"
+            }
+        ],
+        "name": "execute",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "commands",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "inputs",
+                "type": "bytes[]"
+            },
+            {
+                "internalType": "uint256",
+                "name": "deadline",
+                "type": "uint256"
+            }
+        ],
+        "name": "execute",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "name": "onERC1155BatchReceived",
+        "outputs": [
+            {
+                "internalType": "bytes4",
+                "name": "",
+                "type": "bytes4"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "name": "onERC1155Received",
+        "outputs": [
+            {
+                "internalType": "bytes4",
+                "name": "",
+                "type": "bytes4"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "name": "onERC721Received",
+        "outputs": [
+            {
+                "internalType": "bytes4",
+                "name": "",
+                "type": "bytes4"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes4",
+                "name": "interfaceId",
+                "type": "bytes4"
+            }
+        ],
+        "name": "supportsInterface",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "int256",
+                "name": "amount0Delta",
+                "type": "int256"
+            },
+            {
+                "internalType": "int256",
+                "name": "amount1Delta",
+                "type": "int256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "uniswapV3SwapCallback",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "stateMutability": "payable",
+        "type": "receive"
+    }
+]

--- a/avalanche/uniswap/b2c.json
+++ b/avalanche/uniswap/b2c.json
@@ -1,0 +1,18 @@
+{
+    "blockchainName": "avalanche",
+    "chainId": 43114,
+    "contracts": [
+        {
+            "address": "0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad",
+            "contractName": "UniversalRouter",
+            "selectors": {
+                "0x3593564c": {
+                    "erc20OfInterest": [],
+                    "method": "execute",
+                    "plugin": "Uniswap"
+                }
+            }
+        }
+    ],
+    "name": "Uniswap"
+}

--- a/base/uniswap/abis/0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad.abi.json
+++ b/base/uniswap/abis/0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad.abi.json
@@ -1,0 +1,497 @@
+[
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "permit2",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "weth9",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "seaportV1_5",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "seaportV1_4",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "openseaConduit",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nftxZap",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "x2y2",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "foundation",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "sudoswap",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "elementMarket",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nft20Zap",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "cryptopunks",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "looksRareV2",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "routerRewardsDistributor",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "looksRareRewardsDistributor",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "looksRareToken",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "v2Factory",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "v3Factory",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "pairInitCodeHash",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "poolInitCodeHash",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct RouterParameters",
+                "name": "params",
+                "type": "tuple"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "inputs": [],
+        "name": "BalanceTooLow",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "BuyPunkFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ContractLocked",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ETHNotAccepted",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "commandIndex",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "message",
+                "type": "bytes"
+            }
+        ],
+        "name": "ExecutionFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "FromAddressIsNotOwner",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InsufficientETH",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InsufficientToken",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidBips",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "commandType",
+                "type": "uint256"
+            }
+        ],
+        "name": "InvalidCommandType",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidOwnerERC1155",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidOwnerERC721",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidPath",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidReserves",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidSpender",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "LengthMismatch",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "SliceOutOfBounds",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "TransactionDeadlinePassed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "UnableToClaim",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "UnsafeCast",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V2InvalidPath",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V2TooLittleReceived",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V2TooMuchRequested",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3InvalidAmountOut",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3InvalidCaller",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3InvalidSwap",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3TooLittleReceived",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3TooMuchRequested",
+        "type": "error"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "RewardsSent",
+        "type": "event"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "looksRareClaim",
+                "type": "bytes"
+            }
+        ],
+        "name": "collectRewards",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "commands",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "inputs",
+                "type": "bytes[]"
+            }
+        ],
+        "name": "execute",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "commands",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "inputs",
+                "type": "bytes[]"
+            },
+            {
+                "internalType": "uint256",
+                "name": "deadline",
+                "type": "uint256"
+            }
+        ],
+        "name": "execute",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "name": "onERC1155BatchReceived",
+        "outputs": [
+            {
+                "internalType": "bytes4",
+                "name": "",
+                "type": "bytes4"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "name": "onERC1155Received",
+        "outputs": [
+            {
+                "internalType": "bytes4",
+                "name": "",
+                "type": "bytes4"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "name": "onERC721Received",
+        "outputs": [
+            {
+                "internalType": "bytes4",
+                "name": "",
+                "type": "bytes4"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes4",
+                "name": "interfaceId",
+                "type": "bytes4"
+            }
+        ],
+        "name": "supportsInterface",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "int256",
+                "name": "amount0Delta",
+                "type": "int256"
+            },
+            {
+                "internalType": "int256",
+                "name": "amount1Delta",
+                "type": "int256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "uniswapV3SwapCallback",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "stateMutability": "payable",
+        "type": "receive"
+    }
+]

--- a/base/uniswap/b2c.json
+++ b/base/uniswap/b2c.json
@@ -1,0 +1,18 @@
+{
+    "blockchainName": "base",
+    "chainId": 8453,
+    "contracts": [
+        {
+            "address": "0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad",
+            "contractName": "UniversalRouter",
+            "selectors": {
+                "0x3593564c": {
+                    "erc20OfInterest": [],
+                    "method": "execute",
+                    "plugin": "Uniswap"
+                }
+            }
+        }
+    ],
+    "name": "Uniswap"
+}

--- a/blast/b2c.schema.json
+++ b/blast/b2c.schema.json
@@ -1,0 +1,73 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "blockchainName": {
+            "enum": [
+                "blast"
+            ]
+        },
+        "chainId": {
+            "enum": [
+                81457
+            ]
+        },
+        "contracts": {
+            "items": {
+                "properties": {
+                    "address": {
+                        "pattern": "^0x[a-f0-9]{40}$",
+                        "type": "string"
+                    },
+                    "contractName": {
+                        "type": "string"
+                    },
+                    "selectors": {
+                        "additionalProperties": false,
+                        "patternProperties": {
+                            "^0x[a-f0-9]{8}$": {
+                                "properties": {
+                                    "erc20OfInterest": {
+                                        "items": [
+                                            {
+                                                "type": "string"
+                                            }
+                                        ],
+                                        "type": "array"
+                                    },
+                                    "method": {
+                                        "type": "string"
+                                    },
+                                    "plugin": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "plugin"
+                                ],
+                                "type": "object"
+                            }
+                        },
+                        "type": "object"
+                    }
+                },
+                "required": [
+                    "address",
+                    "contractName",
+                    "selectors"
+                ],
+                "type": "object"
+            },
+            "type": "array"
+        },
+        "name": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "blockchainName",
+        "contracts",
+        "name",
+        "chainId"
+    ],
+    "type": "object"
+}

--- a/blast/uniswap/abis/0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad.abi.json
+++ b/blast/uniswap/abis/0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad.abi.json
@@ -1,0 +1,497 @@
+[
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "permit2",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "weth9",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "seaportV1_5",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "seaportV1_4",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "openseaConduit",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nftxZap",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "x2y2",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "foundation",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "sudoswap",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "elementMarket",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nft20Zap",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "cryptopunks",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "looksRareV2",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "routerRewardsDistributor",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "looksRareRewardsDistributor",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "looksRareToken",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "v2Factory",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "v3Factory",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "pairInitCodeHash",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "poolInitCodeHash",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct RouterParameters",
+                "name": "params",
+                "type": "tuple"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "inputs": [],
+        "name": "BalanceTooLow",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "BuyPunkFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ContractLocked",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ETHNotAccepted",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "commandIndex",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "message",
+                "type": "bytes"
+            }
+        ],
+        "name": "ExecutionFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "FromAddressIsNotOwner",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InsufficientETH",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InsufficientToken",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidBips",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "commandType",
+                "type": "uint256"
+            }
+        ],
+        "name": "InvalidCommandType",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidOwnerERC1155",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidOwnerERC721",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidPath",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidReserves",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidSpender",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "LengthMismatch",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "SliceOutOfBounds",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "TransactionDeadlinePassed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "UnableToClaim",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "UnsafeCast",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V2InvalidPath",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V2TooLittleReceived",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V2TooMuchRequested",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3InvalidAmountOut",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3InvalidCaller",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3InvalidSwap",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3TooLittleReceived",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3TooMuchRequested",
+        "type": "error"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "RewardsSent",
+        "type": "event"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "looksRareClaim",
+                "type": "bytes"
+            }
+        ],
+        "name": "collectRewards",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "commands",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "inputs",
+                "type": "bytes[]"
+            }
+        ],
+        "name": "execute",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "commands",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "inputs",
+                "type": "bytes[]"
+            },
+            {
+                "internalType": "uint256",
+                "name": "deadline",
+                "type": "uint256"
+            }
+        ],
+        "name": "execute",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "name": "onERC1155BatchReceived",
+        "outputs": [
+            {
+                "internalType": "bytes4",
+                "name": "",
+                "type": "bytes4"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "name": "onERC1155Received",
+        "outputs": [
+            {
+                "internalType": "bytes4",
+                "name": "",
+                "type": "bytes4"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "name": "onERC721Received",
+        "outputs": [
+            {
+                "internalType": "bytes4",
+                "name": "",
+                "type": "bytes4"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes4",
+                "name": "interfaceId",
+                "type": "bytes4"
+            }
+        ],
+        "name": "supportsInterface",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "int256",
+                "name": "amount0Delta",
+                "type": "int256"
+            },
+            {
+                "internalType": "int256",
+                "name": "amount1Delta",
+                "type": "int256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "uniswapV3SwapCallback",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "stateMutability": "payable",
+        "type": "receive"
+    }
+]

--- a/blast/uniswap/b2c.json
+++ b/blast/uniswap/b2c.json
@@ -1,0 +1,18 @@
+{
+    "blockchainName": "blast",
+    "chainId": 81457,
+    "contracts": [
+        {
+            "address": "0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad",
+            "contractName": "UniversalRouter",
+            "selectors": {
+                "0x3593564c": {
+                    "erc20OfInterest": [],
+                    "method": "execute",
+                    "plugin": "Uniswap"
+                }
+            }
+        }
+    ],
+    "name": "Uniswap"
+}

--- a/bsc/uniswap/abis/0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad.abi.json
+++ b/bsc/uniswap/abis/0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad.abi.json
@@ -1,0 +1,497 @@
+[
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "permit2",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "weth9",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "seaportV1_5",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "seaportV1_4",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "openseaConduit",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nftxZap",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "x2y2",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "foundation",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "sudoswap",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "elementMarket",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nft20Zap",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "cryptopunks",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "looksRareV2",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "routerRewardsDistributor",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "looksRareRewardsDistributor",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "looksRareToken",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "v2Factory",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "v3Factory",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "pairInitCodeHash",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "poolInitCodeHash",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct RouterParameters",
+                "name": "params",
+                "type": "tuple"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "inputs": [],
+        "name": "BalanceTooLow",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "BuyPunkFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ContractLocked",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ETHNotAccepted",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "commandIndex",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "message",
+                "type": "bytes"
+            }
+        ],
+        "name": "ExecutionFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "FromAddressIsNotOwner",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InsufficientETH",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InsufficientToken",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidBips",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "commandType",
+                "type": "uint256"
+            }
+        ],
+        "name": "InvalidCommandType",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidOwnerERC1155",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidOwnerERC721",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidPath",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidReserves",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidSpender",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "LengthMismatch",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "SliceOutOfBounds",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "TransactionDeadlinePassed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "UnableToClaim",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "UnsafeCast",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V2InvalidPath",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V2TooLittleReceived",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V2TooMuchRequested",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3InvalidAmountOut",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3InvalidCaller",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3InvalidSwap",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3TooLittleReceived",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3TooMuchRequested",
+        "type": "error"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "RewardsSent",
+        "type": "event"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "looksRareClaim",
+                "type": "bytes"
+            }
+        ],
+        "name": "collectRewards",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "commands",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "inputs",
+                "type": "bytes[]"
+            }
+        ],
+        "name": "execute",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "commands",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "inputs",
+                "type": "bytes[]"
+            },
+            {
+                "internalType": "uint256",
+                "name": "deadline",
+                "type": "uint256"
+            }
+        ],
+        "name": "execute",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "name": "onERC1155BatchReceived",
+        "outputs": [
+            {
+                "internalType": "bytes4",
+                "name": "",
+                "type": "bytes4"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "name": "onERC1155Received",
+        "outputs": [
+            {
+                "internalType": "bytes4",
+                "name": "",
+                "type": "bytes4"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "name": "onERC721Received",
+        "outputs": [
+            {
+                "internalType": "bytes4",
+                "name": "",
+                "type": "bytes4"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes4",
+                "name": "interfaceId",
+                "type": "bytes4"
+            }
+        ],
+        "name": "supportsInterface",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "int256",
+                "name": "amount0Delta",
+                "type": "int256"
+            },
+            {
+                "internalType": "int256",
+                "name": "amount1Delta",
+                "type": "int256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "uniswapV3SwapCallback",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "stateMutability": "payable",
+        "type": "receive"
+    }
+]

--- a/bsc/uniswap/b2c.json
+++ b/bsc/uniswap/b2c.json
@@ -1,0 +1,18 @@
+{
+    "blockchainName": "bsc",
+    "chainId": 56,
+    "contracts": [
+        {
+            "address": "0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad",
+            "contractName": "UniversalRouter",
+            "selectors": {
+                "0x3593564c": {
+                    "erc20OfInterest": [],
+                    "method": "execute",
+                    "plugin": "Uniswap"
+                }
+            }
+        }
+    ],
+    "name": "Uniswap"
+}

--- a/celo/uniswap/abis/0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad.abi.json
+++ b/celo/uniswap/abis/0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad.abi.json
@@ -1,0 +1,497 @@
+[
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "permit2",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "weth9",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "seaportV1_5",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "seaportV1_4",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "openseaConduit",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nftxZap",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "x2y2",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "foundation",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "sudoswap",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "elementMarket",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nft20Zap",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "cryptopunks",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "looksRareV2",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "routerRewardsDistributor",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "looksRareRewardsDistributor",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "looksRareToken",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "v2Factory",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "v3Factory",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "pairInitCodeHash",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "poolInitCodeHash",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct RouterParameters",
+                "name": "params",
+                "type": "tuple"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "inputs": [],
+        "name": "BalanceTooLow",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "BuyPunkFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ContractLocked",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ETHNotAccepted",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "commandIndex",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "message",
+                "type": "bytes"
+            }
+        ],
+        "name": "ExecutionFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "FromAddressIsNotOwner",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InsufficientETH",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InsufficientToken",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidBips",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "commandType",
+                "type": "uint256"
+            }
+        ],
+        "name": "InvalidCommandType",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidOwnerERC1155",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidOwnerERC721",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidPath",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidReserves",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidSpender",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "LengthMismatch",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "SliceOutOfBounds",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "TransactionDeadlinePassed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "UnableToClaim",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "UnsafeCast",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V2InvalidPath",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V2TooLittleReceived",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V2TooMuchRequested",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3InvalidAmountOut",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3InvalidCaller",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3InvalidSwap",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3TooLittleReceived",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3TooMuchRequested",
+        "type": "error"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "RewardsSent",
+        "type": "event"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "looksRareClaim",
+                "type": "bytes"
+            }
+        ],
+        "name": "collectRewards",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "commands",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "inputs",
+                "type": "bytes[]"
+            }
+        ],
+        "name": "execute",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "commands",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "inputs",
+                "type": "bytes[]"
+            },
+            {
+                "internalType": "uint256",
+                "name": "deadline",
+                "type": "uint256"
+            }
+        ],
+        "name": "execute",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "name": "onERC1155BatchReceived",
+        "outputs": [
+            {
+                "internalType": "bytes4",
+                "name": "",
+                "type": "bytes4"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "name": "onERC1155Received",
+        "outputs": [
+            {
+                "internalType": "bytes4",
+                "name": "",
+                "type": "bytes4"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "name": "onERC721Received",
+        "outputs": [
+            {
+                "internalType": "bytes4",
+                "name": "",
+                "type": "bytes4"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes4",
+                "name": "interfaceId",
+                "type": "bytes4"
+            }
+        ],
+        "name": "supportsInterface",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "int256",
+                "name": "amount0Delta",
+                "type": "int256"
+            },
+            {
+                "internalType": "int256",
+                "name": "amount1Delta",
+                "type": "int256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "uniswapV3SwapCallback",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "stateMutability": "payable",
+        "type": "receive"
+    }
+]

--- a/celo/uniswap/b2c.json
+++ b/celo/uniswap/b2c.json
@@ -1,0 +1,18 @@
+{
+    "blockchainName": "celo",
+    "chainId": 42220,
+    "contracts": [
+        {
+            "address": "0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad",
+            "contractName": "UniversalRouter",
+            "selectors": {
+                "0x3593564c": {
+                    "erc20OfInterest": [],
+                    "method": "execute",
+                    "plugin": "Uniswap"
+                }
+            }
+        }
+    ],
+    "name": "Uniswap"
+}

--- a/ethereum/uniswap/abis/0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad.abi.json
+++ b/ethereum/uniswap/abis/0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad.abi.json
@@ -1,0 +1,497 @@
+[
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "permit2",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "weth9",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "seaportV1_5",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "seaportV1_4",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "openseaConduit",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nftxZap",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "x2y2",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "foundation",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "sudoswap",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "elementMarket",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nft20Zap",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "cryptopunks",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "looksRareV2",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "routerRewardsDistributor",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "looksRareRewardsDistributor",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "looksRareToken",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "v2Factory",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "v3Factory",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "pairInitCodeHash",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "poolInitCodeHash",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct RouterParameters",
+                "name": "params",
+                "type": "tuple"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "inputs": [],
+        "name": "BalanceTooLow",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "BuyPunkFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ContractLocked",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ETHNotAccepted",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "commandIndex",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "message",
+                "type": "bytes"
+            }
+        ],
+        "name": "ExecutionFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "FromAddressIsNotOwner",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InsufficientETH",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InsufficientToken",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidBips",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "commandType",
+                "type": "uint256"
+            }
+        ],
+        "name": "InvalidCommandType",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidOwnerERC1155",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidOwnerERC721",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidPath",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidReserves",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidSpender",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "LengthMismatch",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "SliceOutOfBounds",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "TransactionDeadlinePassed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "UnableToClaim",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "UnsafeCast",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V2InvalidPath",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V2TooLittleReceived",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V2TooMuchRequested",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3InvalidAmountOut",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3InvalidCaller",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3InvalidSwap",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3TooLittleReceived",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3TooMuchRequested",
+        "type": "error"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "RewardsSent",
+        "type": "event"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "looksRareClaim",
+                "type": "bytes"
+            }
+        ],
+        "name": "collectRewards",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "commands",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "inputs",
+                "type": "bytes[]"
+            }
+        ],
+        "name": "execute",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "commands",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "inputs",
+                "type": "bytes[]"
+            },
+            {
+                "internalType": "uint256",
+                "name": "deadline",
+                "type": "uint256"
+            }
+        ],
+        "name": "execute",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "name": "onERC1155BatchReceived",
+        "outputs": [
+            {
+                "internalType": "bytes4",
+                "name": "",
+                "type": "bytes4"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "name": "onERC1155Received",
+        "outputs": [
+            {
+                "internalType": "bytes4",
+                "name": "",
+                "type": "bytes4"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "name": "onERC721Received",
+        "outputs": [
+            {
+                "internalType": "bytes4",
+                "name": "",
+                "type": "bytes4"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes4",
+                "name": "interfaceId",
+                "type": "bytes4"
+            }
+        ],
+        "name": "supportsInterface",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "int256",
+                "name": "amount0Delta",
+                "type": "int256"
+            },
+            {
+                "internalType": "int256",
+                "name": "amount1Delta",
+                "type": "int256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "uniswapV3SwapCallback",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "stateMutability": "payable",
+        "type": "receive"
+    }
+]

--- a/ethereum/uniswap/b2c.json
+++ b/ethereum/uniswap/b2c.json
@@ -1,0 +1,18 @@
+{
+    "blockchainName": "ethereum",
+    "chainId": 1,
+    "contracts": [
+        {
+            "address": "0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad",
+            "contractName": "UniversalRouter",
+            "selectors": {
+                "0x3593564c": {
+                    "erc20OfInterest": [],
+                    "method": "execute",
+                    "plugin": "Uniswap"
+                }
+            }
+        }
+    ],
+    "name": "Uniswap"
+}

--- a/optimism/uniswap/abis/0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad.abi.json
+++ b/optimism/uniswap/abis/0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad.abi.json
@@ -1,0 +1,497 @@
+[
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "permit2",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "weth9",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "seaportV1_5",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "seaportV1_4",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "openseaConduit",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nftxZap",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "x2y2",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "foundation",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "sudoswap",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "elementMarket",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nft20Zap",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "cryptopunks",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "looksRareV2",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "routerRewardsDistributor",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "looksRareRewardsDistributor",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "looksRareToken",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "v2Factory",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "v3Factory",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "pairInitCodeHash",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "poolInitCodeHash",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct RouterParameters",
+                "name": "params",
+                "type": "tuple"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "inputs": [],
+        "name": "BalanceTooLow",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "BuyPunkFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ContractLocked",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ETHNotAccepted",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "commandIndex",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "message",
+                "type": "bytes"
+            }
+        ],
+        "name": "ExecutionFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "FromAddressIsNotOwner",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InsufficientETH",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InsufficientToken",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidBips",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "commandType",
+                "type": "uint256"
+            }
+        ],
+        "name": "InvalidCommandType",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidOwnerERC1155",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidOwnerERC721",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidPath",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidReserves",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidSpender",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "LengthMismatch",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "SliceOutOfBounds",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "TransactionDeadlinePassed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "UnableToClaim",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "UnsafeCast",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V2InvalidPath",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V2TooLittleReceived",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V2TooMuchRequested",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3InvalidAmountOut",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3InvalidCaller",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3InvalidSwap",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3TooLittleReceived",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3TooMuchRequested",
+        "type": "error"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "RewardsSent",
+        "type": "event"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "looksRareClaim",
+                "type": "bytes"
+            }
+        ],
+        "name": "collectRewards",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "commands",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "inputs",
+                "type": "bytes[]"
+            }
+        ],
+        "name": "execute",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "commands",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "inputs",
+                "type": "bytes[]"
+            },
+            {
+                "internalType": "uint256",
+                "name": "deadline",
+                "type": "uint256"
+            }
+        ],
+        "name": "execute",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "name": "onERC1155BatchReceived",
+        "outputs": [
+            {
+                "internalType": "bytes4",
+                "name": "",
+                "type": "bytes4"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "name": "onERC1155Received",
+        "outputs": [
+            {
+                "internalType": "bytes4",
+                "name": "",
+                "type": "bytes4"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "name": "onERC721Received",
+        "outputs": [
+            {
+                "internalType": "bytes4",
+                "name": "",
+                "type": "bytes4"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes4",
+                "name": "interfaceId",
+                "type": "bytes4"
+            }
+        ],
+        "name": "supportsInterface",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "int256",
+                "name": "amount0Delta",
+                "type": "int256"
+            },
+            {
+                "internalType": "int256",
+                "name": "amount1Delta",
+                "type": "int256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "uniswapV3SwapCallback",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "stateMutability": "payable",
+        "type": "receive"
+    }
+]

--- a/optimism/uniswap/b2c.json
+++ b/optimism/uniswap/b2c.json
@@ -1,0 +1,18 @@
+{
+    "blockchainName": "optimism",
+    "chainId": 10,
+    "contracts": [
+        {
+            "address": "0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad",
+            "contractName": "UniversalRouter",
+            "selectors": {
+                "0x3593564c": {
+                    "erc20OfInterest": [],
+                    "method": "execute",
+                    "plugin": "Uniswap"
+                }
+            }
+        }
+    ],
+    "name": "Uniswap"
+}

--- a/polygon/uniswap/abis/0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad.abi.json
+++ b/polygon/uniswap/abis/0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad.abi.json
@@ -1,0 +1,497 @@
+[
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "permit2",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "weth9",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "seaportV1_5",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "seaportV1_4",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "openseaConduit",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nftxZap",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "x2y2",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "foundation",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "sudoswap",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "elementMarket",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "nft20Zap",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "cryptopunks",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "looksRareV2",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "routerRewardsDistributor",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "looksRareRewardsDistributor",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "looksRareToken",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "v2Factory",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "v3Factory",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "pairInitCodeHash",
+                        "type": "bytes32"
+                    },
+                    {
+                        "internalType": "bytes32",
+                        "name": "poolInitCodeHash",
+                        "type": "bytes32"
+                    }
+                ],
+                "internalType": "struct RouterParameters",
+                "name": "params",
+                "type": "tuple"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "inputs": [],
+        "name": "BalanceTooLow",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "BuyPunkFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ContractLocked",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ETHNotAccepted",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "commandIndex",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "message",
+                "type": "bytes"
+            }
+        ],
+        "name": "ExecutionFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "FromAddressIsNotOwner",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InsufficientETH",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InsufficientToken",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidBips",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "commandType",
+                "type": "uint256"
+            }
+        ],
+        "name": "InvalidCommandType",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidOwnerERC1155",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidOwnerERC721",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidPath",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidReserves",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidSpender",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "LengthMismatch",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "SliceOutOfBounds",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "TransactionDeadlinePassed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "UnableToClaim",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "UnsafeCast",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V2InvalidPath",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V2TooLittleReceived",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V2TooMuchRequested",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3InvalidAmountOut",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3InvalidCaller",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3InvalidSwap",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3TooLittleReceived",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "V3TooMuchRequested",
+        "type": "error"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "RewardsSent",
+        "type": "event"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "looksRareClaim",
+                "type": "bytes"
+            }
+        ],
+        "name": "collectRewards",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "commands",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "inputs",
+                "type": "bytes[]"
+            }
+        ],
+        "name": "execute",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "commands",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "inputs",
+                "type": "bytes[]"
+            },
+            {
+                "internalType": "uint256",
+                "name": "deadline",
+                "type": "uint256"
+            }
+        ],
+        "name": "execute",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "name": "onERC1155BatchReceived",
+        "outputs": [
+            {
+                "internalType": "bytes4",
+                "name": "",
+                "type": "bytes4"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "name": "onERC1155Received",
+        "outputs": [
+            {
+                "internalType": "bytes4",
+                "name": "",
+                "type": "bytes4"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "name": "onERC721Received",
+        "outputs": [
+            {
+                "internalType": "bytes4",
+                "name": "",
+                "type": "bytes4"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes4",
+                "name": "interfaceId",
+                "type": "bytes4"
+            }
+        ],
+        "name": "supportsInterface",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "int256",
+                "name": "amount0Delta",
+                "type": "int256"
+            },
+            {
+                "internalType": "int256",
+                "name": "amount1Delta",
+                "type": "int256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "uniswapV3SwapCallback",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "stateMutability": "payable",
+        "type": "receive"
+    }
+]

--- a/polygon/uniswap/b2c.json
+++ b/polygon/uniswap/b2c.json
@@ -1,0 +1,18 @@
+{
+    "blockchainName": "polygon",
+    "chainId": 137,
+    "contracts": [
+        {
+            "address": "0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad",
+            "contractName": "UniversalRouter",
+            "selectors": {
+                "0x3593564c": {
+                    "erc20OfInterest": [],
+                    "method": "execute",
+                    "plugin": "Uniswap"
+                }
+            }
+        }
+    ],
+    "name": "Uniswap"
+}


### PR DESCRIPTION
In order to support the new [Uniswap external plugin](https://github.com/LedgerHQ/app-plugin-uniswap) we need the signature capable of launching the external plugin `Uniswap` with the selector of its `execute` method (https://etherscan.io/address/0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad#writeContract#F3).
No other information is required (like `erc20OfInterest` or ABIs) as the tokens involved are not retrievable via ABI decoding, but require manual parsing, which will be done in `@ledgerhq/hw-app-eth`.