### PR TITLE
EIP-712: implement stricter validations

### DIFF
--- a/arbitrum/eip712.schema.json
+++ b/arbitrum/eip712.schema.json
@@ -44,6 +44,8 @@
                                                         ]
                                                     },
                                                     "label": {
+                                                        "maxLength": 39,
+                                                        "minLength": 1,
                                                         "type": "string"
                                                     },
                                                     "path": {
@@ -56,9 +58,12 @@
                                                 ],
                                                 "type": "object"
                                             },
+                                            "minItems": 1,
                                             "type": "array"
                                         },
                                         "label": {
+                                            "maxLength": 39,
+                                            "minLength": 1,
                                             "type": "string"
                                         }
                                     },
@@ -78,6 +83,7 @@
                             ],
                             "type": "object"
                         },
+                        "minItems": 1,
                         "type": "array"
                     }
                 },
@@ -88,6 +94,7 @@
                 ],
                 "type": "object"
             },
+            "minItems": 1,
             "type": "array"
         },
         "name": {

--- a/arbitrum_sepolia/eip712.schema.json
+++ b/arbitrum_sepolia/eip712.schema.json
@@ -44,6 +44,8 @@
                                                         ]
                                                     },
                                                     "label": {
+                                                        "maxLength": 39,
+                                                        "minLength": 1,
                                                         "type": "string"
                                                     },
                                                     "path": {
@@ -56,9 +58,12 @@
                                                 ],
                                                 "type": "object"
                                             },
+                                            "minItems": 1,
                                             "type": "array"
                                         },
                                         "label": {
+                                            "maxLength": 39,
+                                            "minLength": 1,
                                             "type": "string"
                                         }
                                     },
@@ -78,6 +83,7 @@
                             ],
                             "type": "object"
                         },
+                        "minItems": 1,
                         "type": "array"
                     }
                 },
@@ -88,6 +94,7 @@
                 ],
                 "type": "object"
             },
+            "minItems": 1,
             "type": "array"
         },
         "name": {

--- a/avalanche/eip712.schema.json
+++ b/avalanche/eip712.schema.json
@@ -15,7 +15,7 @@
             "items": {
                 "properties": {
                     "address": {
-                        "pattern": "^0x[a-f0-9]{40}$",
+                        "pattern": "^0x[a-z0-9]{40}$",
                         "type": "string"
                     },
                     "contractName": {
@@ -44,6 +44,8 @@
                                                         ]
                                                     },
                                                     "label": {
+                                                        "maxLength": 39,
+                                                        "minLength": 1,
                                                         "type": "string"
                                                     },
                                                     "path": {
@@ -56,9 +58,12 @@
                                                 ],
                                                 "type": "object"
                                             },
+                                            "minItems": 1,
                                             "type": "array"
                                         },
                                         "label": {
+                                            "maxLength": 39,
+                                            "minLength": 1,
                                             "type": "string"
                                         }
                                     },
@@ -78,6 +83,7 @@
                             ],
                             "type": "object"
                         },
+                        "minItems": 1,
                         "type": "array"
                     }
                 },
@@ -88,6 +94,7 @@
                 ],
                 "type": "object"
             },
+            "minItems": 1,
             "type": "array"
         },
         "name": {

--- a/base/eip712.schema.json
+++ b/base/eip712.schema.json
@@ -44,6 +44,8 @@
                                                         ]
                                                     },
                                                     "label": {
+                                                        "maxLength": 39,
+                                                        "minLength": 1,
                                                         "type": "string"
                                                     },
                                                     "path": {
@@ -56,9 +58,12 @@
                                                 ],
                                                 "type": "object"
                                             },
+                                            "minItems": 1,
                                             "type": "array"
                                         },
                                         "label": {
+                                            "maxLength": 39,
+                                            "minLength": 1,
                                             "type": "string"
                                         }
                                     },
@@ -78,6 +83,7 @@
                             ],
                             "type": "object"
                         },
+                        "minItems": 1,
                         "type": "array"
                     }
                 },
@@ -88,6 +94,7 @@
                 ],
                 "type": "object"
             },
+            "minItems": 1,
             "type": "array"
         },
         "name": {

--- a/base_sepolia/eip712.schema.json
+++ b/base_sepolia/eip712.schema.json
@@ -44,6 +44,8 @@
                                                         ]
                                                     },
                                                     "label": {
+                                                        "maxLength": 39,
+                                                        "minLength": 1,
                                                         "type": "string"
                                                     },
                                                     "path": {
@@ -56,9 +58,12 @@
                                                 ],
                                                 "type": "object"
                                             },
+                                            "minItems": 1,
                                             "type": "array"
                                         },
                                         "label": {
+                                            "maxLength": 39,
+                                            "minLength": 1,
                                             "type": "string"
                                         }
                                     },
@@ -78,6 +83,7 @@
                             ],
                             "type": "object"
                         },
+                        "minItems": 1,
                         "type": "array"
                     }
                 },
@@ -88,6 +94,7 @@
                 ],
                 "type": "object"
             },
+            "minItems": 1,
             "type": "array"
         },
         "name": {

--- a/blast/eip712.schema.json
+++ b/blast/eip712.schema.json
@@ -44,6 +44,8 @@
                                                         ]
                                                     },
                                                     "label": {
+                                                        "maxLength": 39,
+                                                        "minLength": 1,
                                                         "type": "string"
                                                     },
                                                     "path": {
@@ -56,9 +58,12 @@
                                                 ],
                                                 "type": "object"
                                             },
+                                            "minItems": 1,
                                             "type": "array"
                                         },
                                         "label": {
+                                            "maxLength": 39,
+                                            "minLength": 1,
                                             "type": "string"
                                         }
                                     },
@@ -78,6 +83,7 @@
                             ],
                             "type": "object"
                         },
+                        "minItems": 1,
                         "type": "array"
                     }
                 },
@@ -88,6 +94,7 @@
                 ],
                 "type": "object"
             },
+            "minItems": 1,
             "type": "array"
         },
         "name": {

--- a/bsc/eip712.schema.json
+++ b/bsc/eip712.schema.json
@@ -44,6 +44,8 @@
                                                         ]
                                                     },
                                                     "label": {
+                                                        "maxLength": 39,
+                                                        "minLength": 1,
                                                         "type": "string"
                                                     },
                                                     "path": {
@@ -56,9 +58,12 @@
                                                 ],
                                                 "type": "object"
                                             },
+                                            "minItems": 1,
                                             "type": "array"
                                         },
                                         "label": {
+                                            "maxLength": 39,
+                                            "minLength": 1,
                                             "type": "string"
                                         }
                                     },
@@ -78,6 +83,7 @@
                             ],
                             "type": "object"
                         },
+                        "minItems": 1,
                         "type": "array"
                     }
                 },
@@ -88,6 +94,7 @@
                 ],
                 "type": "object"
             },
+            "minItems": 1,
             "type": "array"
         },
         "name": {

--- a/celo/eip712.schema.json
+++ b/celo/eip712.schema.json
@@ -44,6 +44,8 @@
                                                         ]
                                                     },
                                                     "label": {
+                                                        "maxLength": 39,
+                                                        "minLength": 1,
                                                         "type": "string"
                                                     },
                                                     "path": {
@@ -56,9 +58,12 @@
                                                 ],
                                                 "type": "object"
                                             },
+                                            "minItems": 1,
                                             "type": "array"
                                         },
                                         "label": {
+                                            "maxLength": 39,
+                                            "minLength": 1,
                                             "type": "string"
                                         }
                                     },
@@ -78,6 +83,7 @@
                             ],
                             "type": "object"
                         },
+                        "minItems": 1,
                         "type": "array"
                     }
                 },
@@ -88,6 +94,7 @@
                 ],
                 "type": "object"
             },
+            "minItems": 1,
             "type": "array"
         },
         "name": {

--- a/ethereum/eip712.schema.json
+++ b/ethereum/eip712.schema.json
@@ -44,6 +44,8 @@
                                                         ]
                                                     },
                                                     "label": {
+                                                        "maxLength": 39,
+                                                        "minLength": 1,
                                                         "type": "string"
                                                     },
                                                     "path": {
@@ -56,9 +58,12 @@
                                                 ],
                                                 "type": "object"
                                             },
+                                            "minItems": 1,
                                             "type": "array"
                                         },
                                         "label": {
+                                            "maxLength": 39,
+                                            "minLength": 1,
                                             "type": "string"
                                         }
                                     },
@@ -78,6 +83,7 @@
                             ],
                             "type": "object"
                         },
+                        "minItems": 1,
                         "type": "array"
                     }
                 },
@@ -88,6 +94,7 @@
                 ],
                 "type": "object"
             },
+            "minItems": 1,
             "type": "array"
         },
         "name": {

--- a/ethereum/smartcredit/eip712.json
+++ b/ethereum/smartcredit/eip712.json
@@ -8,7 +8,36 @@
             "messages": [
                 {
                     "mapper": {
-                        "fields": [],
+                        "fields": [
+                            {
+                                "label": "Collateral address",
+                                "path": "collateralAddress"
+                            },
+                            {
+                                "label": "Initial Collateral Amount",
+                                "path": "initialCollateralAmount"
+                            },
+                            {
+                                "label": "Loan Amount",
+                                "path": "loanAmount"
+                            },
+                            {
+                                "label": "Loan ID",
+                                "path": "loanId"
+                            },
+                            {
+                                "label": "Loan interest rate",
+                                "path": "loanInterestRate"
+                            },
+                            {
+                                "label": "Load Term",
+                                "path": "loanTerm"
+                            },
+                            {
+                                "label": "Underlying Address",
+                                "path": "underlyingAddress"
+                            }
+                        ],
                         "label": "SmartCredit.io"
                     },
                     "schema": {

--- a/ethereum_sepolia/eip712.schema.json
+++ b/ethereum_sepolia/eip712.schema.json
@@ -44,6 +44,8 @@
                                                         ]
                                                     },
                                                     "label": {
+                                                        "maxLength": 39,
+                                                        "minLength": 1,
                                                         "type": "string"
                                                     },
                                                     "path": {
@@ -56,9 +58,12 @@
                                                 ],
                                                 "type": "object"
                                             },
+                                            "minItems": 1,
                                             "type": "array"
                                         },
                                         "label": {
+                                            "maxLength": 39,
+                                            "minLength": 1,
                                             "type": "string"
                                         }
                                     },
@@ -78,6 +83,7 @@
                             ],
                             "type": "object"
                         },
+                        "minItems": 1,
                         "type": "array"
                     }
                 },
@@ -88,6 +94,7 @@
                 ],
                 "type": "object"
             },
+            "minItems": 1,
             "type": "array"
         },
         "name": {

--- a/fantom/eip712.schema.json
+++ b/fantom/eip712.schema.json
@@ -44,6 +44,8 @@
                                                         ]
                                                     },
                                                     "label": {
+                                                        "maxLength": 39,
+                                                        "minLength": 1,
                                                         "type": "string"
                                                     },
                                                     "path": {
@@ -56,9 +58,12 @@
                                                 ],
                                                 "type": "object"
                                             },
+                                            "minItems": 1,
                                             "type": "array"
                                         },
                                         "label": {
+                                            "maxLength": 39,
+                                            "minLength": 1,
                                             "type": "string"
                                         }
                                     },
@@ -78,6 +83,7 @@
                             ],
                             "type": "object"
                         },
+                        "minItems": 1,
                         "type": "array"
                     }
                 },
@@ -88,6 +94,7 @@
                 ],
                 "type": "object"
             },
+            "minItems": 1,
             "type": "array"
         },
         "name": {

--- a/optimism/eip712.schema.json
+++ b/optimism/eip712.schema.json
@@ -44,6 +44,8 @@
                                                         ]
                                                     },
                                                     "label": {
+                                                        "maxLength": 39,
+                                                        "minLength": 1,
                                                         "type": "string"
                                                     },
                                                     "path": {
@@ -56,9 +58,12 @@
                                                 ],
                                                 "type": "object"
                                             },
+                                            "minItems": 1,
                                             "type": "array"
                                         },
                                         "label": {
+                                            "maxLength": 39,
+                                            "minLength": 1,
                                             "type": "string"
                                         }
                                     },
@@ -78,6 +83,7 @@
                             ],
                             "type": "object"
                         },
+                        "minItems": 1,
                         "type": "array"
                     }
                 },
@@ -88,6 +94,7 @@
                 ],
                 "type": "object"
             },
+            "minItems": 1,
             "type": "array"
         },
         "name": {

--- a/optimism_sepolia/eip712.schema.json
+++ b/optimism_sepolia/eip712.schema.json
@@ -44,6 +44,8 @@
                                                         ]
                                                     },
                                                     "label": {
+                                                        "maxLength": 39,
+                                                        "minLength": 1,
                                                         "type": "string"
                                                     },
                                                     "path": {
@@ -56,9 +58,12 @@
                                                 ],
                                                 "type": "object"
                                             },
+                                            "minItems": 1,
                                             "type": "array"
                                         },
                                         "label": {
+                                            "maxLength": 39,
+                                            "minLength": 1,
                                             "type": "string"
                                         }
                                     },
@@ -78,6 +83,7 @@
                             ],
                             "type": "object"
                         },
+                        "minItems": 1,
                         "type": "array"
                     }
                 },
@@ -88,6 +94,7 @@
                 ],
                 "type": "object"
             },
+            "minItems": 1,
             "type": "array"
         },
         "name": {

--- a/polygon/eip712.schema.json
+++ b/polygon/eip712.schema.json
@@ -44,6 +44,8 @@
                                                         ]
                                                     },
                                                     "label": {
+                                                        "maxLength": 39,
+                                                        "minLength": 1,
                                                         "type": "string"
                                                     },
                                                     "path": {
@@ -56,9 +58,12 @@
                                                 ],
                                                 "type": "object"
                                             },
+                                            "minItems": 1,
                                             "type": "array"
                                         },
                                         "label": {
+                                            "maxLength": 39,
+                                            "minLength": 1,
                                             "type": "string"
                                         }
                                     },
@@ -78,6 +83,7 @@
                             ],
                             "type": "object"
                         },
+                        "minItems": 1,
                         "type": "array"
                     }
                 },
@@ -88,6 +94,7 @@
                 ],
                 "type": "object"
             },
+            "minItems": 1,
             "type": "array"
         },
         "name": {

--- a/polygon_mumbai/eip712.schema.json
+++ b/polygon_mumbai/eip712.schema.json
@@ -44,6 +44,8 @@
                                                         ]
                                                     },
                                                     "label": {
+                                                        "maxLength": 39,
+                                                        "minLength": 1,
                                                         "type": "string"
                                                     },
                                                     "path": {
@@ -56,9 +58,12 @@
                                                 ],
                                                 "type": "object"
                                             },
+                                            "minItems": 1,
                                             "type": "array"
                                         },
                                         "label": {
+                                            "maxLength": 39,
+                                            "minLength": 1,
                                             "type": "string"
                                         }
                                     },
@@ -78,6 +83,7 @@
                             ],
                             "type": "object"
                         },
+                        "minItems": 1,
                         "type": "array"
                     }
                 },
@@ -88,6 +94,7 @@
                 ],
                 "type": "object"
             },
+            "minItems": 1,
             "type": "array"
         },
         "name": {

--- a/polygon_zk_evm/eip712.schema.json
+++ b/polygon_zk_evm/eip712.schema.json
@@ -44,6 +44,8 @@
                                                         ]
                                                     },
                                                     "label": {
+                                                        "maxLength": 39,
+                                                        "minLength": 1,
                                                         "type": "string"
                                                     },
                                                     "path": {
@@ -56,9 +58,12 @@
                                                 ],
                                                 "type": "object"
                                             },
+                                            "minItems": 1,
                                             "type": "array"
                                         },
                                         "label": {
+                                            "maxLength": 39,
+                                            "minLength": 1,
                                             "type": "string"
                                         }
                                     },
@@ -78,6 +83,7 @@
                             ],
                             "type": "object"
                         },
+                        "minItems": 1,
                         "type": "array"
                     }
                 },
@@ -88,6 +94,7 @@
                 ],
                 "type": "object"
             },
+            "minItems": 1,
             "type": "array"
         },
         "name": {

--- a/scroll/eip712.schema.json
+++ b/scroll/eip712.schema.json
@@ -44,6 +44,8 @@
                                                         ]
                                                     },
                                                     "label": {
+                                                        "maxLength": 39,
+                                                        "minLength": 1,
                                                         "type": "string"
                                                     },
                                                     "path": {
@@ -56,9 +58,12 @@
                                                 ],
                                                 "type": "object"
                                             },
+                                            "minItems": 1,
                                             "type": "array"
                                         },
                                         "label": {
+                                            "maxLength": 39,
+                                            "minLength": 1,
                                             "type": "string"
                                         }
                                     },
@@ -78,6 +83,7 @@
                             ],
                             "type": "object"
                         },
+                        "minItems": 1,
                         "type": "array"
                     }
                 },
@@ -88,6 +94,7 @@
                 ],
                 "type": "object"
             },
+            "minItems": 1,
             "type": "array"
         },
         "name": {


### PR DESCRIPTION
- forbid empty labels, or longer than 39 characters (ethereum app limit)
- forbid empty mappings / empty messages or contracts lists
- fix SmartCredit.io descriptor breaking rule (just show all fields)