### PR TITLE
BACK-7356: remove `format=token` from EIP-712 schemas

### DIFF
--- a/arbitrum/1inch/eip712.json
+++ b/arbitrum/1inch/eip712.json
@@ -14,20 +14,10 @@
                                 "path": "maker"
                             },
                             {
-                                "format": "token",
-                                "label": "Swap Token",
-                                "path": "makerAsset"
-                            },
-                            {
                                 "assetPath": "makerAsset",
                                 "format": "amount",
                                 "label": "Swap Amount",
                                 "path": "makingAmount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Receive Token",
-                                "path": "takerAsset"
                             },
                             {
                                 "assetPath": "takerAsset",
@@ -105,20 +95,10 @@
                                 "path": "maker"
                             },
                             {
-                                "format": "token",
-                                "label": "Swap Token",
-                                "path": "makerAsset"
-                            },
-                            {
                                 "assetPath": "makerAsset",
                                 "format": "amount",
                                 "label": "Swap Amount",
                                 "path": "makingAmount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Receive Token",
-                                "path": "takerAsset"
                             },
                             {
                                 "assetPath": "takerAsset",
@@ -210,20 +190,10 @@
                                 "path": "maker"
                             },
                             {
-                                "format": "token",
-                                "label": "Swap Token",
-                                "path": "makerAsset"
-                            },
-                            {
                                 "assetPath": "makerAsset",
                                 "format": "amount",
                                 "label": "Swap Amount",
                                 "path": "makingAmount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Receive Token",
-                                "path": "takerAsset"
                             },
                             {
                                 "assetPath": "takerAsset",

--- a/arbitrum/eip712.schema.json
+++ b/arbitrum/eip712.schema.json
@@ -37,7 +37,6 @@
                                                     },
                                                     "format": {
                                                         "enum": [
-                                                            "token",
                                                             "amount",
                                                             "raw",
                                                             "datetime"

--- a/arbitrum/permit/eip712.json
+++ b/arbitrum/permit/eip712.json
@@ -18,6 +18,7 @@
                                 "path": "spender"
                             },
                             {
+                                "format": "amount",
                                 "label": "Allowance",
                                 "path": "value"
                             },
@@ -90,6 +91,7 @@
                                 "path": "spender"
                             },
                             {
+                                "format": "amount",
                                 "label": "Allowance",
                                 "path": "value"
                             },

--- a/arbitrum/uniswap/eip712.json
+++ b/arbitrum/uniswap/eip712.json
@@ -10,11 +10,6 @@
                     "mapper": {
                         "fields": [
                             {
-                                "format": "token",
-                                "label": "Token",
-                                "path": "details.token"
-                            },
-                            {
                                 "assetPath": "details.token",
                                 "format": "amount",
                                 "label": "Amount",
@@ -89,20 +84,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",
@@ -245,20 +230,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",
@@ -417,20 +392,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",

--- a/arbitrum_sepolia/eip712.schema.json
+++ b/arbitrum_sepolia/eip712.schema.json
@@ -37,7 +37,6 @@
                                                     },
                                                     "format": {
                                                         "enum": [
-                                                            "token",
                                                             "amount",
                                                             "raw",
                                                             "datetime"

--- a/arbitrum_sepolia/uniswap/eip712.json
+++ b/arbitrum_sepolia/uniswap/eip712.json
@@ -10,11 +10,6 @@
                     "mapper": {
                         "fields": [
                             {
-                                "format": "token",
-                                "label": "Token",
-                                "path": "details.token"
-                            },
-                            {
                                 "assetPath": "details.token",
                                 "format": "amount",
                                 "label": "Amount",
@@ -89,20 +84,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",
@@ -245,20 +230,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",
@@ -417,20 +392,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",

--- a/avalanche/eip712.schema.json
+++ b/avalanche/eip712.schema.json
@@ -37,7 +37,6 @@
                                                     },
                                                     "format": {
                                                         "enum": [
-                                                            "token",
                                                             "amount",
                                                             "raw",
                                                             "datetime"

--- a/avalanche/permit/eip712.json
+++ b/avalanche/permit/eip712.json
@@ -18,6 +18,7 @@
                                 "path": "spender"
                             },
                             {
+                                "format": "amount",
                                 "label": "Allowance",
                                 "path": "value"
                             },
@@ -90,6 +91,7 @@
                                 "path": "spender"
                             },
                             {
+                                "format": "amount",
                                 "label": "Allowance",
                                 "path": "value"
                             },

--- a/avalanche/uniswap/eip712.json
+++ b/avalanche/uniswap/eip712.json
@@ -10,11 +10,6 @@
                     "mapper": {
                         "fields": [
                             {
-                                "format": "token",
-                                "label": "Token",
-                                "path": "details.token"
-                            },
-                            {
                                 "assetPath": "details.token",
                                 "format": "amount",
                                 "label": "Amount",
@@ -89,20 +84,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",
@@ -245,20 +230,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",
@@ -417,20 +392,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",

--- a/base/eip712.schema.json
+++ b/base/eip712.schema.json
@@ -37,7 +37,6 @@
                                                     },
                                                     "format": {
                                                         "enum": [
-                                                            "token",
                                                             "amount",
                                                             "raw",
                                                             "datetime"

--- a/base/uniswap/eip712.json
+++ b/base/uniswap/eip712.json
@@ -10,11 +10,6 @@
                     "mapper": {
                         "fields": [
                             {
-                                "format": "token",
-                                "label": "Token",
-                                "path": "details.token"
-                            },
-                            {
                                 "assetPath": "details.token",
                                 "format": "amount",
                                 "label": "Amount",
@@ -89,20 +84,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",
@@ -245,20 +230,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",
@@ -417,20 +392,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",

--- a/base_sepolia/eip712.schema.json
+++ b/base_sepolia/eip712.schema.json
@@ -37,7 +37,6 @@
                                                     },
                                                     "format": {
                                                         "enum": [
-                                                            "token",
                                                             "amount",
                                                             "raw",
                                                             "datetime"

--- a/base_sepolia/uniswap/eip712.json
+++ b/base_sepolia/uniswap/eip712.json
@@ -10,11 +10,6 @@
                     "mapper": {
                         "fields": [
                             {
-                                "format": "token",
-                                "label": "Token",
-                                "path": "details.token"
-                            },
-                            {
                                 "assetPath": "details.token",
                                 "format": "amount",
                                 "label": "Amount",
@@ -89,20 +84,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",
@@ -245,20 +230,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",
@@ -417,20 +392,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",

--- a/blast/eip712.schema.json
+++ b/blast/eip712.schema.json
@@ -37,7 +37,6 @@
                                                     },
                                                     "format": {
                                                         "enum": [
-                                                            "token",
                                                             "amount",
                                                             "raw",
                                                             "datetime"

--- a/blast/uniswap/eip712.json
+++ b/blast/uniswap/eip712.json
@@ -10,11 +10,6 @@
                     "mapper": {
                         "fields": [
                             {
-                                "format": "token",
-                                "label": "Token",
-                                "path": "details.token"
-                            },
-                            {
                                 "assetPath": "details.token",
                                 "format": "amount",
                                 "label": "Amount",
@@ -89,20 +84,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",
@@ -245,20 +230,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",
@@ -417,20 +392,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",

--- a/bsc/1inch/eip712.json
+++ b/bsc/1inch/eip712.json
@@ -14,20 +14,10 @@
                                 "path": "maker"
                             },
                             {
-                                "format": "token",
-                                "label": "Swap Token",
-                                "path": "makerAsset"
-                            },
-                            {
                                 "assetPath": "makerAsset",
                                 "format": "amount",
                                 "label": "Swap Amount",
                                 "path": "makingAmount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Receive Token",
-                                "path": "takerAsset"
                             },
                             {
                                 "assetPath": "takerAsset",
@@ -105,20 +95,10 @@
                                 "path": "maker"
                             },
                             {
-                                "format": "token",
-                                "label": "Swap Token",
-                                "path": "makerAsset"
-                            },
-                            {
                                 "assetPath": "makerAsset",
                                 "format": "amount",
                                 "label": "Swap Amount",
                                 "path": "makingAmount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Receive Token",
-                                "path": "takerAsset"
                             },
                             {
                                 "assetPath": "takerAsset",
@@ -210,20 +190,10 @@
                                 "path": "maker"
                             },
                             {
-                                "format": "token",
-                                "label": "Swap Token",
-                                "path": "makerAsset"
-                            },
-                            {
                                 "assetPath": "makerAsset",
                                 "format": "amount",
                                 "label": "Swap Amount",
                                 "path": "makingAmount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Receive Token",
-                                "path": "takerAsset"
                             },
                             {
                                 "assetPath": "takerAsset",

--- a/bsc/eip712.schema.json
+++ b/bsc/eip712.schema.json
@@ -37,7 +37,6 @@
                                                     },
                                                     "format": {
                                                         "enum": [
-                                                            "token",
                                                             "amount",
                                                             "raw",
                                                             "datetime"

--- a/bsc/permit/eip712.json
+++ b/bsc/permit/eip712.json
@@ -18,6 +18,7 @@
                                 "path": "spender"
                             },
                             {
+                                "format": "amount",
                                 "label": "Allowance",
                                 "path": "value"
                             },
@@ -90,6 +91,7 @@
                                 "path": "spender"
                             },
                             {
+                                "format": "amount",
                                 "label": "Allowance",
                                 "path": "value"
                             },

--- a/bsc/uniswap/eip712.json
+++ b/bsc/uniswap/eip712.json
@@ -10,11 +10,6 @@
                     "mapper": {
                         "fields": [
                             {
-                                "format": "token",
-                                "label": "Token",
-                                "path": "details.token"
-                            },
-                            {
                                 "assetPath": "details.token",
                                 "format": "amount",
                                 "label": "Amount",
@@ -89,20 +84,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",
@@ -245,20 +230,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",
@@ -417,20 +392,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",

--- a/celo/eip712.schema.json
+++ b/celo/eip712.schema.json
@@ -37,7 +37,6 @@
                                                     },
                                                     "format": {
                                                         "enum": [
-                                                            "token",
                                                             "amount",
                                                             "raw",
                                                             "datetime"

--- a/celo/uniswap/eip712.json
+++ b/celo/uniswap/eip712.json
@@ -10,11 +10,6 @@
                     "mapper": {
                         "fields": [
                             {
-                                "format": "token",
-                                "label": "Token",
-                                "path": "details.token"
-                            },
-                            {
                                 "assetPath": "details.token",
                                 "format": "amount",
                                 "label": "Amount",
@@ -89,20 +84,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",
@@ -245,20 +230,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",
@@ -417,20 +392,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",

--- a/ethereum/1inch/eip712.json
+++ b/ethereum/1inch/eip712.json
@@ -14,20 +14,10 @@
                                 "path": "maker"
                             },
                             {
-                                "format": "token",
-                                "label": "Swap Token",
-                                "path": "makerAsset"
-                            },
-                            {
                                 "assetPath": "makerAsset",
                                 "format": "amount",
                                 "label": "Swap Amount",
                                 "path": "makingAmount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Receive Token",
-                                "path": "takerAsset"
                             },
                             {
                                 "assetPath": "takerAsset",
@@ -105,20 +95,10 @@
                                 "path": "maker"
                             },
                             {
-                                "format": "token",
-                                "label": "Swap Token",
-                                "path": "makerAsset"
-                            },
-                            {
                                 "assetPath": "makerAsset",
                                 "format": "amount",
                                 "label": "Swap Amount",
                                 "path": "makingAmount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Receive Token",
-                                "path": "takerAsset"
                             },
                             {
                                 "assetPath": "takerAsset",
@@ -210,20 +190,10 @@
                                 "path": "maker"
                             },
                             {
-                                "format": "token",
-                                "label": "Swap Token",
-                                "path": "makerAsset"
-                            },
-                            {
                                 "assetPath": "makerAsset",
                                 "format": "amount",
                                 "label": "Swap Amount",
                                 "path": "makingAmount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Receive Token",
-                                "path": "takerAsset"
                             },
                             {
                                 "assetPath": "takerAsset",

--- a/ethereum/eip712.schema.json
+++ b/ethereum/eip712.schema.json
@@ -37,7 +37,6 @@
                                                     },
                                                     "format": {
                                                         "enum": [
-                                                            "token",
                                                             "amount",
                                                             "raw",
                                                             "datetime"

--- a/ethereum/permit/eip712.json
+++ b/ethereum/permit/eip712.json
@@ -18,6 +18,7 @@
                                 "path": "spender"
                             },
                             {
+                                "format": "amount",
                                 "label": "Allowance",
                                 "path": "value"
                             },
@@ -90,6 +91,7 @@
                                 "path": "spender"
                             },
                             {
+                                "format": "amount",
                                 "label": "Allowance",
                                 "path": "value"
                             },
@@ -162,6 +164,7 @@
                                 "path": "spender"
                             },
                             {
+                                "format": "amount",
                                 "label": "Allowance",
                                 "path": "value"
                             },

--- a/ethereum/uniswap/eip712.json
+++ b/ethereum/uniswap/eip712.json
@@ -10,11 +10,6 @@
                     "mapper": {
                         "fields": [
                             {
-                                "format": "token",
-                                "label": "Token",
-                                "path": "details.token"
-                            },
-                            {
                                 "assetPath": "details.token",
                                 "format": "amount",
                                 "label": "Amount",
@@ -89,20 +84,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",
@@ -245,20 +230,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",
@@ -417,20 +392,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",

--- a/ethereum_sepolia/eip712.schema.json
+++ b/ethereum_sepolia/eip712.schema.json
@@ -37,7 +37,6 @@
                                                     },
                                                     "format": {
                                                         "enum": [
-                                                            "token",
                                                             "amount",
                                                             "raw",
                                                             "datetime"

--- a/ethereum_sepolia/uniswap/eip712.json
+++ b/ethereum_sepolia/uniswap/eip712.json
@@ -10,11 +10,6 @@
                     "mapper": {
                         "fields": [
                             {
-                                "format": "token",
-                                "label": "Token",
-                                "path": "details.token"
-                            },
-                            {
                                 "assetPath": "details.token",
                                 "format": "amount",
                                 "label": "Amount",
@@ -89,20 +84,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",
@@ -245,20 +230,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",
@@ -417,20 +392,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",

--- a/fantom/eip712.schema.json
+++ b/fantom/eip712.schema.json
@@ -37,7 +37,6 @@
                                                     },
                                                     "format": {
                                                         "enum": [
-                                                            "token",
                                                             "amount",
                                                             "raw",
                                                             "datetime"

--- a/fantom/permit/eip712.json
+++ b/fantom/permit/eip712.json
@@ -18,6 +18,7 @@
                                 "path": "spender"
                             },
                             {
+                                "format": "amount",
                                 "label": "Allowance",
                                 "path": "value"
                             },
@@ -90,6 +91,7 @@
                                 "path": "spender"
                             },
                             {
+                                "format": "amount",
                                 "label": "Allowance",
                                 "path": "value"
                             },

--- a/optimism/1inch/eip712.json
+++ b/optimism/1inch/eip712.json
@@ -14,20 +14,10 @@
                                 "path": "maker"
                             },
                             {
-                                "format": "token",
-                                "label": "Swap Token",
-                                "path": "makerAsset"
-                            },
-                            {
                                 "assetPath": "makerAsset",
                                 "format": "amount",
                                 "label": "Swap Amount",
                                 "path": "makingAmount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Receive Token",
-                                "path": "takerAsset"
                             },
                             {
                                 "assetPath": "takerAsset",
@@ -105,20 +95,10 @@
                                 "path": "maker"
                             },
                             {
-                                "format": "token",
-                                "label": "Swap Token",
-                                "path": "makerAsset"
-                            },
-                            {
                                 "assetPath": "makerAsset",
                                 "format": "amount",
                                 "label": "Swap Amount",
                                 "path": "makingAmount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Receive Token",
-                                "path": "takerAsset"
                             },
                             {
                                 "assetPath": "takerAsset",
@@ -210,20 +190,10 @@
                                 "path": "maker"
                             },
                             {
-                                "format": "token",
-                                "label": "Swap Token",
-                                "path": "makerAsset"
-                            },
-                            {
                                 "assetPath": "makerAsset",
                                 "format": "amount",
                                 "label": "Swap Amount",
                                 "path": "makingAmount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Receive Token",
-                                "path": "takerAsset"
                             },
                             {
                                 "assetPath": "takerAsset",

--- a/optimism/eip712.schema.json
+++ b/optimism/eip712.schema.json
@@ -37,7 +37,6 @@
                                                     },
                                                     "format": {
                                                         "enum": [
-                                                            "token",
                                                             "amount",
                                                             "raw",
                                                             "datetime"

--- a/optimism/permit/eip712.json
+++ b/optimism/permit/eip712.json
@@ -18,6 +18,7 @@
                                 "path": "spender"
                             },
                             {
+                                "format": "amount",
                                 "label": "Allowance",
                                 "path": "value"
                             },
@@ -90,6 +91,7 @@
                                 "path": "spender"
                             },
                             {
+                                "format": "amount",
                                 "label": "Allowance",
                                 "path": "value"
                             },

--- a/optimism/uniswap/eip712.json
+++ b/optimism/uniswap/eip712.json
@@ -10,11 +10,6 @@
                     "mapper": {
                         "fields": [
                             {
-                                "format": "token",
-                                "label": "Token",
-                                "path": "details.token"
-                            },
-                            {
                                 "assetPath": "details.token",
                                 "format": "amount",
                                 "label": "Amount",
@@ -89,20 +84,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",
@@ -245,20 +230,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",
@@ -417,20 +392,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",

--- a/optimism_sepolia/eip712.schema.json
+++ b/optimism_sepolia/eip712.schema.json
@@ -37,7 +37,6 @@
                                                     },
                                                     "format": {
                                                         "enum": [
-                                                            "token",
                                                             "amount",
                                                             "raw",
                                                             "datetime"

--- a/optimism_sepolia/uniswap/eip712.json
+++ b/optimism_sepolia/uniswap/eip712.json
@@ -10,11 +10,6 @@
                     "mapper": {
                         "fields": [
                             {
-                                "format": "token",
-                                "label": "Token",
-                                "path": "details.token"
-                            },
-                            {
                                 "assetPath": "details.token",
                                 "format": "amount",
                                 "label": "Amount",
@@ -89,20 +84,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",
@@ -245,20 +230,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",
@@ -417,20 +392,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",

--- a/polygon/1inch/eip712.json
+++ b/polygon/1inch/eip712.json
@@ -14,20 +14,10 @@
                                 "path": "maker"
                             },
                             {
-                                "format": "token",
-                                "label": "Swap Token",
-                                "path": "makerAsset"
-                            },
-                            {
                                 "assetPath": "makerAsset",
                                 "format": "amount",
                                 "label": "Swap Amount",
                                 "path": "makingAmount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Receive Token",
-                                "path": "takerAsset"
                             },
                             {
                                 "assetPath": "takerAsset",
@@ -105,20 +95,10 @@
                                 "path": "maker"
                             },
                             {
-                                "format": "token",
-                                "label": "Swap Token",
-                                "path": "makerAsset"
-                            },
-                            {
                                 "assetPath": "makerAsset",
                                 "format": "amount",
                                 "label": "Swap Amount",
                                 "path": "makingAmount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Receive Token",
-                                "path": "takerAsset"
                             },
                             {
                                 "assetPath": "takerAsset",
@@ -210,20 +190,10 @@
                                 "path": "maker"
                             },
                             {
-                                "format": "token",
-                                "label": "Swap Token",
-                                "path": "makerAsset"
-                            },
-                            {
                                 "assetPath": "makerAsset",
                                 "format": "amount",
                                 "label": "Swap Amount",
                                 "path": "makingAmount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Receive Token",
-                                "path": "takerAsset"
                             },
                             {
                                 "assetPath": "takerAsset",

--- a/polygon/eip712.schema.json
+++ b/polygon/eip712.schema.json
@@ -37,7 +37,6 @@
                                                     },
                                                     "format": {
                                                         "enum": [
-                                                            "token",
                                                             "amount",
                                                             "raw",
                                                             "datetime"

--- a/polygon/permit/eip712.json
+++ b/polygon/permit/eip712.json
@@ -18,6 +18,7 @@
                                 "path": "spender"
                             },
                             {
+                                "format": "amount",
                                 "label": "Allowance",
                                 "path": "value"
                             },
@@ -90,6 +91,7 @@
                                 "path": "spender"
                             },
                             {
+                                "format": "amount",
                                 "label": "Allowance",
                                 "path": "value"
                             },

--- a/polygon/uniswap/eip712.json
+++ b/polygon/uniswap/eip712.json
@@ -10,11 +10,6 @@
                     "mapper": {
                         "fields": [
                             {
-                                "format": "token",
-                                "label": "Token",
-                                "path": "details.token"
-                            },
-                            {
                                 "assetPath": "details.token",
                                 "format": "amount",
                                 "label": "Amount",
@@ -89,20 +84,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",
@@ -245,20 +230,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",
@@ -417,20 +392,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",

--- a/polygon_mumbai/eip712.schema.json
+++ b/polygon_mumbai/eip712.schema.json
@@ -37,7 +37,6 @@
                                                     },
                                                     "format": {
                                                         "enum": [
-                                                            "token",
                                                             "amount",
                                                             "raw",
                                                             "datetime"

--- a/polygon_mumbai/uniswap/eip712.json
+++ b/polygon_mumbai/uniswap/eip712.json
@@ -10,11 +10,6 @@
                     "mapper": {
                         "fields": [
                             {
-                                "format": "token",
-                                "label": "Token",
-                                "path": "details.token"
-                            },
-                            {
                                 "assetPath": "details.token",
                                 "format": "amount",
                                 "label": "Amount",
@@ -89,20 +84,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",
@@ -245,20 +230,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",
@@ -417,20 +392,10 @@
                                 "path": "spender"
                             },
                             {
-                                "format": "token",
-                                "label": "Approve token",
-                                "path": "permitted.token"
-                            },
-                            {
                                 "assetPath": "permitted.token",
                                 "format": "amount",
                                 "label": "Approve amount",
                                 "path": "permitted.amount"
-                            },
-                            {
-                                "format": "token",
-                                "label": "Token to swap",
-                                "path": "witness.inputToken"
                             },
                             {
                                 "assetPath": "witness.inputToken",

--- a/polygon_zk_evm/eip712.schema.json
+++ b/polygon_zk_evm/eip712.schema.json
@@ -37,7 +37,6 @@
                                                     },
                                                     "format": {
                                                         "enum": [
-                                                            "token",
                                                             "amount",
                                                             "raw",
                                                             "datetime"

--- a/scroll/eip712.schema.json
+++ b/scroll/eip712.schema.json
@@ -37,7 +37,6 @@
                                                     },
                                                     "format": {
                                                         "enum": [
-                                                            "token",
                                                             "amount",
                                                             "raw",
                                                             "datetime"


### PR DESCRIPTION
See:
- https://ledgerhq.atlassian.net/browse/BACK-7356
- LedgerHQ/python-eip712#7
- LedgerHQ/crypto-assets#1192
