### PR TITLE
BACK-7352: Permit EIP-712: switch allowance to `format=amount`

### DIFF
--- a/arbitrum/permit/eip712.json
+++ b/arbitrum/permit/eip712.json
@@ -18,6 +18,7 @@
                                 "path": "spender"
                             },
                             {
+                                "format": "amount",
                                 "label": "Allowance",
                                 "path": "value"
                             },
@@ -90,6 +91,7 @@
                                 "path": "spender"
                             },
                             {
+                                "format": "amount",
                                 "label": "Allowance",
                                 "path": "value"
                             },

--- a/avalanche/permit/eip712.json
+++ b/avalanche/permit/eip712.json
@@ -18,6 +18,7 @@
                                 "path": "spender"
                             },
                             {
+                                "format": "amount",
                                 "label": "Allowance",
                                 "path": "value"
                             },
@@ -90,6 +91,7 @@
                                 "path": "spender"
                             },
                             {
+                                "format": "amount",
                                 "label": "Allowance",
                                 "path": "value"
                             },

--- a/bsc/permit/eip712.json
+++ b/bsc/permit/eip712.json
@@ -18,6 +18,7 @@
                                 "path": "spender"
                             },
                             {
+                                "format": "amount",
                                 "label": "Allowance",
                                 "path": "value"
                             },
@@ -90,6 +91,7 @@
                                 "path": "spender"
                             },
                             {
+                                "format": "amount",
                                 "label": "Allowance",
                                 "path": "value"
                             },

--- a/ethereum/permit/eip712.json
+++ b/ethereum/permit/eip712.json
@@ -18,6 +18,7 @@
                                 "path": "spender"
                             },
                             {
+                                "format": "amount",
                                 "label": "Allowance",
                                 "path": "value"
                             },
@@ -90,6 +91,7 @@
                                 "path": "spender"
                             },
                             {
+                                "format": "amount",
                                 "label": "Allowance",
                                 "path": "value"
                             },
@@ -162,6 +164,7 @@
                                 "path": "spender"
                             },
                             {
+                                "format": "amount",
                                 "label": "Allowance",
                                 "path": "value"
                             },

--- a/fantom/permit/eip712.json
+++ b/fantom/permit/eip712.json
@@ -18,6 +18,7 @@
                                 "path": "spender"
                             },
                             {
+                                "format": "amount",
                                 "label": "Allowance",
                                 "path": "value"
                             },
@@ -90,6 +91,7 @@
                                 "path": "spender"
                             },
                             {
+                                "format": "amount",
                                 "label": "Allowance",
                                 "path": "value"
                             },

--- a/optimism/permit/eip712.json
+++ b/optimism/permit/eip712.json
@@ -18,6 +18,7 @@
                                 "path": "spender"
                             },
                             {
+                                "format": "amount",
                                 "label": "Allowance",
                                 "path": "value"
                             },
@@ -90,6 +91,7 @@
                                 "path": "spender"
                             },
                             {
+                                "format": "amount",
                                 "label": "Allowance",
                                 "path": "value"
                             },

--- a/polygon/permit/eip712.json
+++ b/polygon/permit/eip712.json
@@ -18,6 +18,7 @@
                                 "path": "spender"
                             },
                             {
+                                "format": "amount",
                                 "label": "Allowance",
                                 "path": "value"
                             },
@@ -90,6 +91,7 @@
                                 "path": "spender"
                             },
                             {
+                                "format": "amount",
                                 "label": "Allowance",
                                 "path": "value"
                             },


### PR DESCRIPTION
Will default to `verifyingContract` as the token ref.

See:
 - https://ledgerhq.atlassian.net/browse/BACK-7352
 - https://github.com/LedgerHQ/crypto-assets/pull/1194
 - https://github.com/LedgerHQ/python-eip712/pull/8