### PR TITLE
ci: add missing permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
   lint:
     name: Static analysis
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
 
       - name: Checkout


### PR DESCRIPTION
CI fails at PR comment for external contriibutors: https://github.com/LedgerHQ/ledger-asset-dapps/actions/runs/9989369000/job/27673680234?pr=202#step:7:143