### PR TITLE
BACK-7439: only allow one plugin for a given (chain_id, contract, selector) triplet

### DIFF
--- a/scripts/validate_files.py
+++ b/scripts/validate_files.py
@@ -19,6 +19,7 @@ from validation.validators import (
     contract_matching_validator,
     missing_schema_validator,
     eip55_address_validator,
+    check_duplicate_plugin,
 )
 
 logging.basicConfig(level="INFO")
@@ -64,6 +65,8 @@ if __name__ == "__main__":
     try:
         logger.info("Running duplicate contract check")
         check_duplicate_contract("./*/**/b2c.json")
+        logger.info("Running duplicate plugin check")
+        check_duplicate_plugin("./*/**/b2c.json")
     except ValidationError:
         failed = True
 

--- a/scripts/validation/validators.py
+++ b/scripts/validation/validators.py
@@ -173,8 +173,8 @@ def check_duplicate_plugin(glob_path: str):
                 record = {
                     "filename": filename,
                     "blockchain": blockchain,
-                    "contract": address,
-                    "selector": selector,
+                    "contract": address.lower(),
+                    "selector": selector.lower(),
                     "plugin": plugin,
                 }
                 logger.debug(f"adding record {record}")
@@ -192,9 +192,10 @@ def check_duplicate_plugin(glob_path: str):
                 all[(blockchain, contract, selector)] = record
             elif existing_record["plugin"] != plugin:
                 invalid += 1
-                errors.append(f"file {filename} and file {existing_record['filename']} reference "
-                              f"different plugins the (blockchain={blockchain}, contract={contract}, selector={selector}) triplet, "
-                              f"the first has plugin={plugin} and the second {existing_record['plugin']}")
+                errors.append(f"File {filename} and file {existing_record['filename']} bind "
+                              f"(blockchain={blockchain}, contract={contract}, selector={selector}) to different plugins "
+                              f"{plugin} and {existing_record['plugin']} respectively, "
+                              f"please remove one of the bindings")
 
     if invalid:
         for error in errors:

--- a/scripts/validation/validators.py
+++ b/scripts/validation/validators.py
@@ -45,6 +45,10 @@ __excluded_contract = [
     "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
 ]
 
+__excluded_contracts_from_plugin_collision = [
+    "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+]
+
 
 def check_duplicate_contract(glob_path: str):
     invalid, errors, results, all = 0, [], [], {}
@@ -129,6 +133,68 @@ def check_duplicate_contract(glob_path: str):
                             }
                         )
                     all[contract_address] = {**existing, **data}
+
+    if invalid:
+        for error in errors:
+            logger.error(f"Validation error: {error}")
+        raise ValidationError(f"Invalid files: {errors}")
+
+
+def check_duplicate_plugin(glob_path: str):
+    invalid, errors, results, all = 0, [], [], {}
+    for filename in glob.iglob(glob_path, recursive=True):
+        logger.debug("Validating %s... for duplicate plugins", filename)
+        with open(filename, "r", newline="") as f:
+            data = f.read()
+
+        try:
+            target_data = json.loads(data)
+        except JSONDecodeError as err:
+            logger.debug(
+                "\tinvalid: File %s is not a valid json", filename, exc_info=True
+            )
+            errors.append({"file": filename, "message": str(err)})
+            continue
+
+        records = []
+        blockchain = target_data.get("blockchainName", None)
+        for contract in target_data.get("contracts", []):
+            address = contract.get("address", None)
+            if address is None:
+                continue
+            elif address in __excluded_contracts_from_plugin_collision:
+                continue
+
+            address = address.lower()
+
+            for selector, data in contract.get("selectors", []).items():
+                plugin = data["plugin"]
+
+                record = {
+                    "filename": filename,
+                    "blockchain": blockchain,
+                    "contract": address,
+                    "selector": selector,
+                    "plugin": plugin,
+                }
+                logger.debug(f"adding record {record}")
+                records.append(record)
+
+        # check if among the records there are multiple plugins associated with a given (chain_id, contract, selector) triplet
+        for record in records:
+            filename = record["filename"]
+            blockchain = record["blockchain"]
+            contract = record["contract"]
+            selector = record["selector"]
+            plugin = record["plugin"]
+            existing_record = all.get((blockchain, contract, selector), None)
+            if existing_record is None:
+                all[(blockchain, contract, selector)] = record
+            elif existing_record["plugin"] != plugin:
+                invalid += 1
+                errors.append(f"file {filename} and file {existing_record['filename']} reference "
+                              f"different plugins the (blockchain={blockchain}, contract={contract}, selector={selector}) triplet, "
+                              f"the first has plugin={plugin} and the second {existing_record['plugin']}")
 
     if invalid:
         for error in errors:

--- a/scripts/validation/validators.py
+++ b/scripts/validation/validators.py
@@ -165,8 +165,6 @@ def check_duplicate_plugin(glob_path: str):
             elif address in __excluded_contracts_from_plugin_collision:
                 continue
 
-            address = address.lower()
-
             for selector, data in contract.get("selectors", []).items():
                 plugin = data["plugin"]
 


### PR DESCRIPTION
Only allow one plugin for a given (chain_id, contract, selector) triplet

i.e. what we want to forbid is
```
(ethereum, 0xa356867fdcea8e71aeaf87805808803806231fdc, 0x1e6d24c2, DODO)
(ethereum, 0xa356867fdcea8e71aeaf87805808803806231fdc, 0x1e6d24c2, Harvest)
```

In that case a message like this, is printed:

```
Validation error: File ./ethereum/opensea/b2c.json and file ./ethereum/dodo/b2c.json 
bind (blockchain=ethereum, contract=0xa356867fdcea8e71aeaf87805808803806231fdc, 
selector=0x1e6d24c2) to different plugins DODO and Harvest respectively, 
please remove one of the bindings
```
