### PR TITLE
ci: trigger update on LedgerHQ/python-erc7730 on merge to main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        repo: ['LedgerHQ/crypto-assets', 'LedgerHQ/crypto-assets-clear-signing-initiative']
+        repo: ['LedgerHQ/crypto-assets', 'LedgerHQ/crypto-assets-clear-signing-initiative', 'LedgerHQ/python-erc7730']
     steps:
       - name: Trigger update on ${{ matrix.repo }}
         timeout-minutes: 60


### PR DESCRIPTION
LedgerHQ/python-erc7730 also uses LedgerHQ/ledger-asset-dapps for integration tests.

