### PR TITLE
ci: remove trigger on archived repository

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        repo: ['LedgerHQ/crypto-assets', 'LedgerHQ/crypto-assets-clear-signing-initiative', 'LedgerHQ/python-erc7730']
+        repo: ['LedgerHQ/crypto-assets', 'LedgerHQ/python-erc7730']
     steps:
       - name: Trigger update on ${{ matrix.repo }}
         timeout-minutes: 60


### PR DESCRIPTION
`LedgerHQ/crypto-assets-clear-signing-initiative` is now merged and archived

