### PR TITLE
feat(LIVE-15089): Add descriptors for ParaSwap & 1-inch on Base

### DIFF
--- a/base/1inch/abis/0x1111111254eeb25477b68fb85ed929f73a960582.abi.json
+++ b/base/1inch/abis/0x1111111254eeb25477b68fb85ed929f73a960582.abi.json
@@ -1,0 +1,2188 @@
+[
+    {
+        "inputs": [
+            {
+                "internalType": "contract IWETH",
+                "name": "weth",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "inputs": [],
+        "name": "AccessDenied",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "AdvanceNonceFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "AlreadyFilled",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ArbitraryStaticCallFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "BadPool",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "BadSignature",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ETHTransferFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ETHTransferFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "EmptyPools",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "EthDepositRejected",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "GetAmountCallFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "IncorrectDataLength",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InsufficientBalance",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidMsgValue",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidMsgValue",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidatedOrder",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "MakingAmountExceeded",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "MakingAmountTooLow",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "OnlyOneAmountShouldBeZero",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "OrderExpired",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "PermitLengthTooLow",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "PredicateIsNotTrue",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "PrivateOrder",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "RFQBadSignature",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "RFQPrivateOrder",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "RFQSwapWithZeroAmount",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "RFQZeroTargetIsForbidden",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ReentrancyDetected",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "RemainingAmountIsZero",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ReservesCallFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ReturnAmountIsNotEnough",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "SafePermitBadLength",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "SafeTransferFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "SafeTransferFromFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bool",
+                "name": "success",
+                "type": "bool"
+            },
+            {
+                "internalType": "bytes",
+                "name": "res",
+                "type": "bytes"
+            }
+        ],
+        "name": "SimulationResults",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "SwapAmountTooLarge",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "SwapWithZeroAmount",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "TakingAmountExceeded",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "TakingAmountIncreased",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "TakingAmountTooHigh",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "TransferFromMakerToTakerFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "TransferFromTakerToMakerFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "UnknownOrder",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "WrongAmount",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "WrongGetter",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ZeroAddress",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ZeroMinReturn",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ZeroReturnAmount",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ZeroTargetIsForbidden",
+        "type": "error"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "maker",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "newNonce",
+                "type": "uint256"
+            }
+        ],
+        "name": "NonceIncreased",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "maker",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes32",
+                "name": "orderHash",
+                "type": "bytes32"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "remainingRaw",
+                "type": "uint256"
+            }
+        ],
+        "name": "OrderCanceled",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "maker",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes32",
+                "name": "orderHash",
+                "type": "bytes32"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "remaining",
+                "type": "uint256"
+            }
+        ],
+        "name": "OrderFilled",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "bytes32",
+                "name": "orderHash",
+                "type": "bytes32"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "makingAmount",
+                "type": "uint256"
+            }
+        ],
+        "name": "OrderFilledRFQ",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "previousOwner",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "newOwner",
+                "type": "address"
+            }
+        ],
+        "name": "OwnershipTransferred",
+        "type": "event"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint8",
+                "name": "amount",
+                "type": "uint8"
+            }
+        ],
+        "name": "advanceNonce",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "offsets",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "and",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "target",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "arbitraryStaticCall",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "uint256",
+                        "name": "salt",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "makerAsset",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "takerAsset",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "receiver",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "allowedSender",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "makingAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "takingAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "offsets",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "bytes",
+                        "name": "interactions",
+                        "type": "bytes"
+                    }
+                ],
+                "internalType": "struct OrderLib.Order",
+                "name": "order",
+                "type": "tuple"
+            }
+        ],
+        "name": "cancelOrder",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "orderRemaining",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "orderHash",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "orderInfo",
+                "type": "uint256"
+            }
+        ],
+        "name": "cancelOrderRFQ",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "orderInfo",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "additionalMask",
+                "type": "uint256"
+            }
+        ],
+        "name": "cancelOrderRFQ",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "uint256",
+                        "name": "salt",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "makerAsset",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "takerAsset",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "receiver",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "allowedSender",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "makingAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "takingAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "offsets",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "bytes",
+                        "name": "interactions",
+                        "type": "bytes"
+                    }
+                ],
+                "internalType": "struct OrderLib.Order",
+                "name": "order",
+                "type": "tuple"
+            }
+        ],
+        "name": "checkPredicate",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "contract IClipperExchangeInterface",
+                "name": "clipperExchange",
+                "type": "address"
+            },
+            {
+                "internalType": "contract IERC20",
+                "name": "srcToken",
+                "type": "address"
+            },
+            {
+                "internalType": "contract IERC20",
+                "name": "dstToken",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "inputAmount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "outputAmount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "goodUntil",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "r",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "vs",
+                "type": "bytes32"
+            }
+        ],
+        "name": "clipperSwap",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "returnAmount",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "contract IClipperExchangeInterface",
+                "name": "clipperExchange",
+                "type": "address"
+            },
+            {
+                "internalType": "address payable",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "internalType": "contract IERC20",
+                "name": "srcToken",
+                "type": "address"
+            },
+            {
+                "internalType": "contract IERC20",
+                "name": "dstToken",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "inputAmount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "outputAmount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "goodUntil",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "r",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "vs",
+                "type": "bytes32"
+            }
+        ],
+        "name": "clipperSwapTo",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "returnAmount",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "contract IClipperExchangeInterface",
+                "name": "clipperExchange",
+                "type": "address"
+            },
+            {
+                "internalType": "address payable",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "internalType": "contract IERC20",
+                "name": "srcToken",
+                "type": "address"
+            },
+            {
+                "internalType": "contract IERC20",
+                "name": "dstToken",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "inputAmount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "outputAmount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "goodUntil",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "r",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "vs",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "bytes",
+                "name": "permit",
+                "type": "bytes"
+            }
+        ],
+        "name": "clipperSwapToWithPermit",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "returnAmount",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "destroy",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "eq",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "uint256",
+                        "name": "salt",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "makerAsset",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "takerAsset",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "receiver",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "allowedSender",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "makingAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "takingAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "offsets",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "bytes",
+                        "name": "interactions",
+                        "type": "bytes"
+                    }
+                ],
+                "internalType": "struct OrderLib.Order",
+                "name": "order",
+                "type": "tuple"
+            },
+            {
+                "internalType": "bytes",
+                "name": "signature",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes",
+                "name": "interaction",
+                "type": "bytes"
+            },
+            {
+                "internalType": "uint256",
+                "name": "makingAmount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "takingAmount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "skipPermitAndThresholdAmount",
+                "type": "uint256"
+            }
+        ],
+        "name": "fillOrder",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "uint256",
+                        "name": "info",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "makerAsset",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "takerAsset",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "allowedSender",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "makingAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "takingAmount",
+                        "type": "uint256"
+                    }
+                ],
+                "internalType": "struct OrderRFQLib.OrderRFQ",
+                "name": "order",
+                "type": "tuple"
+            },
+            {
+                "internalType": "bytes",
+                "name": "signature",
+                "type": "bytes"
+            },
+            {
+                "internalType": "uint256",
+                "name": "flagsAndAmount",
+                "type": "uint256"
+            }
+        ],
+        "name": "fillOrderRFQ",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "uint256",
+                        "name": "info",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "makerAsset",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "takerAsset",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "allowedSender",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "makingAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "takingAmount",
+                        "type": "uint256"
+                    }
+                ],
+                "internalType": "struct OrderRFQLib.OrderRFQ",
+                "name": "order",
+                "type": "tuple"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "r",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "vs",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "uint256",
+                "name": "flagsAndAmount",
+                "type": "uint256"
+            }
+        ],
+        "name": "fillOrderRFQCompact",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "filledMakingAmount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "filledTakingAmount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "orderHash",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "uint256",
+                        "name": "info",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "makerAsset",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "takerAsset",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "allowedSender",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "makingAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "takingAmount",
+                        "type": "uint256"
+                    }
+                ],
+                "internalType": "struct OrderRFQLib.OrderRFQ",
+                "name": "order",
+                "type": "tuple"
+            },
+            {
+                "internalType": "bytes",
+                "name": "signature",
+                "type": "bytes"
+            },
+            {
+                "internalType": "uint256",
+                "name": "flagsAndAmount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "target",
+                "type": "address"
+            }
+        ],
+        "name": "fillOrderRFQTo",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "filledMakingAmount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "filledTakingAmount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "orderHash",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "uint256",
+                        "name": "info",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "makerAsset",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "takerAsset",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "allowedSender",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "makingAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "takingAmount",
+                        "type": "uint256"
+                    }
+                ],
+                "internalType": "struct OrderRFQLib.OrderRFQ",
+                "name": "order",
+                "type": "tuple"
+            },
+            {
+                "internalType": "bytes",
+                "name": "signature",
+                "type": "bytes"
+            },
+            {
+                "internalType": "uint256",
+                "name": "flagsAndAmount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "target",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes",
+                "name": "permit",
+                "type": "bytes"
+            }
+        ],
+        "name": "fillOrderRFQToWithPermit",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "uint256",
+                        "name": "salt",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "makerAsset",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "takerAsset",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "receiver",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "allowedSender",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "makingAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "takingAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "offsets",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "bytes",
+                        "name": "interactions",
+                        "type": "bytes"
+                    }
+                ],
+                "internalType": "struct OrderLib.Order",
+                "name": "order_",
+                "type": "tuple"
+            },
+            {
+                "internalType": "bytes",
+                "name": "signature",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes",
+                "name": "interaction",
+                "type": "bytes"
+            },
+            {
+                "internalType": "uint256",
+                "name": "makingAmount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "takingAmount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "skipPermitAndThresholdAmount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "target",
+                "type": "address"
+            }
+        ],
+        "name": "fillOrderTo",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "actualMakingAmount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "actualTakingAmount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "orderHash",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "uint256",
+                        "name": "salt",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "makerAsset",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "takerAsset",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "receiver",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "allowedSender",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "makingAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "takingAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "offsets",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "bytes",
+                        "name": "interactions",
+                        "type": "bytes"
+                    }
+                ],
+                "internalType": "struct OrderLib.Order",
+                "name": "order",
+                "type": "tuple"
+            },
+            {
+                "internalType": "bytes",
+                "name": "signature",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes",
+                "name": "interaction",
+                "type": "bytes"
+            },
+            {
+                "internalType": "uint256",
+                "name": "makingAmount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "takingAmount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "skipPermitAndThresholdAmount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "target",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes",
+                "name": "permit",
+                "type": "bytes"
+            }
+        ],
+        "name": "fillOrderToWithPermit",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "gt",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "uint256",
+                        "name": "salt",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "makerAsset",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "takerAsset",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "maker",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "receiver",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "allowedSender",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "makingAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "takingAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "offsets",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "bytes",
+                        "name": "interactions",
+                        "type": "bytes"
+                    }
+                ],
+                "internalType": "struct OrderLib.Order",
+                "name": "order",
+                "type": "tuple"
+            }
+        ],
+        "name": "hashOrder",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "increaseNonce",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "maker",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "slot",
+                "type": "uint256"
+            }
+        ],
+        "name": "invalidatorForOrderRFQ",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "lt",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "nonce",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "makerAddress",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "makerNonce",
+                "type": "uint256"
+            }
+        ],
+        "name": "nonceEquals",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "offsets",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "or",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "owner",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "orderHash",
+                "type": "bytes32"
+            }
+        ],
+        "name": "remaining",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "orderHash",
+                "type": "bytes32"
+            }
+        ],
+        "name": "remainingRaw",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32[]",
+                "name": "orderHashes",
+                "type": "bytes32[]"
+            }
+        ],
+        "name": "remainingsRaw",
+        "outputs": [
+            {
+                "internalType": "uint256[]",
+                "name": "",
+                "type": "uint256[]"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "renounceOwnership",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "contract IERC20",
+                "name": "token",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "rescueFunds",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "target",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "simulate",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "contract IAggregationExecutor",
+                "name": "executor",
+                "type": "address"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "srcToken",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "contract IERC20",
+                        "name": "dstToken",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address payable",
+                        "name": "srcReceiver",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address payable",
+                        "name": "dstReceiver",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "amount",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "minReturnAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "flags",
+                        "type": "uint256"
+                    }
+                ],
+                "internalType": "struct GenericRouter.SwapDescription",
+                "name": "desc",
+                "type": "tuple"
+            },
+            {
+                "internalType": "bytes",
+                "name": "permit",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "swap",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "returnAmount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "spentAmount",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "time",
+                "type": "uint256"
+            }
+        ],
+        "name": "timestampBelow",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "timeNonceAccount",
+                "type": "uint256"
+            }
+        ],
+        "name": "timestampBelowAndNonceEquals",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "newOwner",
+                "type": "address"
+            }
+        ],
+        "name": "transferOwnership",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "minReturn",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "pools",
+                "type": "uint256[]"
+            }
+        ],
+        "name": "uniswapV3Swap",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "returnAmount",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "int256",
+                "name": "amount0Delta",
+                "type": "int256"
+            },
+            {
+                "internalType": "int256",
+                "name": "amount1Delta",
+                "type": "int256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "uniswapV3SwapCallback",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address payable",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "minReturn",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "pools",
+                "type": "uint256[]"
+            }
+        ],
+        "name": "uniswapV3SwapTo",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "returnAmount",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address payable",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "internalType": "contract IERC20",
+                "name": "srcToken",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "minReturn",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "pools",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "bytes",
+                "name": "permit",
+                "type": "bytes"
+            }
+        ],
+        "name": "uniswapV3SwapToWithPermit",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "returnAmount",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "contract IERC20",
+                "name": "srcToken",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "minReturn",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "pools",
+                "type": "uint256[]"
+            }
+        ],
+        "name": "unoswap",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "returnAmount",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address payable",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "internalType": "contract IERC20",
+                "name": "srcToken",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "minReturn",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "pools",
+                "type": "uint256[]"
+            }
+        ],
+        "name": "unoswapTo",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "returnAmount",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address payable",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "internalType": "contract IERC20",
+                "name": "srcToken",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "minReturn",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "pools",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "bytes",
+                "name": "permit",
+                "type": "bytes"
+            }
+        ],
+        "name": "unoswapToWithPermit",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "returnAmount",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "stateMutability": "payable",
+        "type": "receive"
+    }
+]

--- a/base/1inch/b2c.json
+++ b/base/1inch/b2c.json
@@ -1,0 +1,67 @@
+{
+    "blockchainName": "base",
+    "chainId": 8453,
+    "contracts": [
+        {
+            "address": "0x1111111254eeb25477b68fb85ed929f73a960582",
+            "contractName": "AggregationRouterV5",
+            "selectors": {
+                "0x0502b1c5": {
+                    "erc20OfInterest": [
+                        "srcToken"
+                    ],
+                    "method": "unoswap",
+                    "plugin": "1inch"
+                },
+                "0x12aa3caf": {
+                    "erc20OfInterest": [
+                        "desc.srcToken",
+                        "desc.dstToken"
+                    ],
+                    "method": "swap",
+                    "plugin": "1inch"
+                },
+                "0x3c15fd91": {
+                    "erc20OfInterest": [
+                        "srcToken"
+                    ],
+                    "method": "unoswapToWithPermit",
+                    "plugin": "1inch"
+                },
+                "0x3eca9c0a": {
+                    "erc20OfInterest": [
+                        "order.makerAsset",
+                        "order.takerAsset"
+                    ],
+                    "method": "fillOrderRFQ",
+                    "plugin": "1inch"
+                },
+                "0x70ccbd31": {
+                    "erc20OfInterest": [
+                        "order.makerAsset",
+                        "order.takerAsset"
+                    ],
+                    "method": "fillOrderRFQToWithPermit",
+                    "plugin": "1inch"
+                },
+                "0x84bd6d29": {
+                    "erc20OfInterest": [
+                        "srcToken",
+                        "dstToken"
+                    ],
+                    "method": "clipperSwap",
+                    "plugin": "1inch"
+                },
+                "0xc805a666": {
+                    "erc20OfInterest": [
+                        "srcToken",
+                        "dstToken"
+                    ],
+                    "method": "clipperSwapToWithPermit",
+                    "plugin": "1inch"
+                }
+            }
+        }
+    ],
+    "name": "1inch"
+}

--- a/base/1inch/eip712.json
+++ b/base/1inch/eip712.json
@@ -1,0 +1,94 @@
+{
+    "blockchainName": "base",
+    "chainId": 8453,
+    "contracts": [
+        {
+            "address": "0x1111111254eeb25477b68fb85ed929f73a960582",
+            "contractName": "1inch Aggregation Router",
+            "messages": [
+                {
+                    "mapper": {
+                        "fields": [
+                            {
+                                "label": "From",
+                                "path": "maker"
+                            },
+                            {
+                                "assetPath": "makerAsset",
+                                "format": "amount",
+                                "label": "Send",
+                                "path": "makingAmount"
+                            },
+                            {
+                                "assetPath": "takerAsset",
+                                "format": "amount",
+                                "label": "Receive minimum",
+                                "path": "takingAmount"
+                            },
+                            {
+                                "label": "To",
+                                "path": "receiver"
+                            }
+                        ],
+                        "label": "1inch Order"
+                    },
+                    "schema": {
+                        "EIP712Domain": [
+                            {
+                                "name": "name",
+                                "type": "string"
+                            },
+                            {
+                                "name": "version",
+                                "type": "string"
+                            },
+                            {
+                                "name": "chainId",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "verifyingContract",
+                                "type": "address"
+                            }
+                        ],
+                        "Order": [
+                            {
+                                "name": "salt",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "maker",
+                                "type": "address"
+                            },
+                            {
+                                "name": "receiver",
+                                "type": "address"
+                            },
+                            {
+                                "name": "makerAsset",
+                                "type": "address"
+                            },
+                            {
+                                "name": "takerAsset",
+                                "type": "address"
+                            },
+                            {
+                                "name": "makingAmount",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "takingAmount",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "makerTraits",
+                                "type": "uint256"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    ],
+    "name": "Permit2"
+}

--- a/base/paraswap/abis/0x59c7c832e96d2568bea6db468c1aadcbbda08a52.abi.json
+++ b/base/paraswap/abis/0x59c7c832e96d2568bea6db468c1aadcbbda08a52.abi.json
@@ -1,0 +1,619 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address payable",
+        "name": "_feeWallet",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      }
+    ],
+    "name": "AdapterInitialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "previousAdminRole",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "newAdminRole",
+        "type": "bytes32"
+      }
+    ],
+    "name": "RoleAdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleRevoked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "router",
+        "type": "address"
+      }
+    ],
+    "name": "RouterInitialized",
+    "type": "event"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "fallback"
+  },
+  {
+    "inputs": [],
+    "name": "DEFAULT_ADMIN_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ROUTER_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "WHITELISTED_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "key",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getAdapterData",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getFeeWallet",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "selector",
+        "type": "bytes4"
+      }
+    ],
+    "name": "getImplementation",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "partner",
+        "type": "address"
+      }
+    ],
+    "name": "getPartnerFeeStructure",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "partnerShare",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "noPositiveSlippage",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "positiveSlippageToUser",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint16",
+            "name": "feePercent",
+            "type": "uint16"
+          },
+          {
+            "internalType": "string",
+            "name": "partnerId",
+            "type": "string"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct AugustusStorage.FeeStructure",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRoleAdmin",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "getRoleMember",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRoleMemberCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "key",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRouterData",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getTokenTransferProxy",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getVersion",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "grantRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "hasRole",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "initializeAdapter",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "router",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "initializeRouter",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "key",
+        "type": "bytes32"
+      }
+    ],
+    "name": "isAdapterInitialized",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "key",
+        "type": "bytes32"
+      }
+    ],
+    "name": "isRouterInitialized",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "partner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_partnerShare",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "_noPositiveSlippage",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "_positiveSlippageToUser",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint16",
+        "name": "_feePercent",
+        "type": "uint16"
+      },
+      {
+        "internalType": "string",
+        "name": "partnerId",
+        "type": "string"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "registerPartner",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "renounceRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "revokeRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address payable",
+        "name": "_feeWallet",
+        "type": "address"
+      }
+    ],
+    "name": "setFeeWallet",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "selector",
+        "type": "bytes4"
+      },
+      {
+        "internalType": "address",
+        "name": "implementation",
+        "type": "address"
+      }
+    ],
+    "name": "setImplementation",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "address payable",
+        "name": "destination",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferTokens",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
+  }
+]

--- a/base/paraswap/abis/0x59c7c832e96d2568bea6db468c1aadcbbda08a52.abi.json
+++ b/base/paraswap/abis/0x59c7c832e96d2568bea6db468c1aadcbbda08a52.abi.json
@@ -1,619 +1,619 @@
 [
-  {
-    "inputs": [
-      {
-        "internalType": "address payable",
-        "name": "_feeWallet",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "nonpayable",
-    "type": "constructor"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "adapter",
-        "type": "address"
-      }
-    ],
-    "name": "AdapterInitialized",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "bytes32",
-        "name": "role",
-        "type": "bytes32"
-      },
-      {
-        "indexed": true,
-        "internalType": "bytes32",
-        "name": "previousAdminRole",
-        "type": "bytes32"
-      },
-      {
-        "indexed": true,
-        "internalType": "bytes32",
-        "name": "newAdminRole",
-        "type": "bytes32"
-      }
-    ],
-    "name": "RoleAdminChanged",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "bytes32",
-        "name": "role",
-        "type": "bytes32"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "sender",
-        "type": "address"
-      }
-    ],
-    "name": "RoleGranted",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "bytes32",
-        "name": "role",
-        "type": "bytes32"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "sender",
-        "type": "address"
-      }
-    ],
-    "name": "RoleRevoked",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "router",
-        "type": "address"
-      }
-    ],
-    "name": "RouterInitialized",
-    "type": "event"
-  },
-  {
-    "stateMutability": "payable",
-    "type": "fallback"
-  },
-  {
-    "inputs": [],
-    "name": "DEFAULT_ADMIN_ROLE",
-    "outputs": [
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "ROUTER_ROLE",
-    "outputs": [
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "WHITELISTED_ROLE",
-    "outputs": [
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "key",
-        "type": "bytes32"
-      }
-    ],
-    "name": "getAdapterData",
-    "outputs": [
-      {
-        "internalType": "bytes",
-        "name": "",
-        "type": "bytes"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "getFeeWallet",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes4",
-        "name": "selector",
-        "type": "bytes4"
-      }
-    ],
-    "name": "getImplementation",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "partner",
-        "type": "address"
-      }
-    ],
-    "name": "getPartnerFeeStructure",
-    "outputs": [
-      {
-        "components": [
-          {
-            "internalType": "uint256",
-            "name": "partnerShare",
-            "type": "uint256"
-          },
-          {
-            "internalType": "bool",
-            "name": "noPositiveSlippage",
-            "type": "bool"
-          },
-          {
-            "internalType": "bool",
-            "name": "positiveSlippageToUser",
-            "type": "bool"
-          },
-          {
-            "internalType": "uint16",
-            "name": "feePercent",
-            "type": "uint16"
-          },
-          {
-            "internalType": "string",
-            "name": "partnerId",
-            "type": "string"
-          },
-          {
-            "internalType": "bytes",
-            "name": "data",
-            "type": "bytes"
-          }
+    {
+        "inputs": [
+            {
+                "internalType": "address payable",
+                "name": "_feeWallet",
+                "type": "address"
+            }
         ],
-        "internalType": "struct AugustusStorage.FeeStructure",
-        "name": "",
-        "type": "tuple"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "role",
-        "type": "bytes32"
-      }
-    ],
-    "name": "getRoleAdmin",
-    "outputs": [
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "role",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "uint256",
-        "name": "index",
-        "type": "uint256"
-      }
-    ],
-    "name": "getRoleMember",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "role",
-        "type": "bytes32"
-      }
-    ],
-    "name": "getRoleMemberCount",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "key",
-        "type": "bytes32"
-      }
-    ],
-    "name": "getRouterData",
-    "outputs": [
-      {
-        "internalType": "bytes",
-        "name": "",
-        "type": "bytes"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "getTokenTransferProxy",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "getVersion",
-    "outputs": [
-      {
-        "internalType": "string",
-        "name": "",
-        "type": "string"
-      }
-    ],
-    "stateMutability": "pure",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "role",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      }
-    ],
-    "name": "grantRole",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "role",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      }
-    ],
-    "name": "hasRole",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "adapter",
-        "type": "address"
-      },
-      {
-        "internalType": "bytes",
-        "name": "data",
-        "type": "bytes"
-      }
-    ],
-    "name": "initializeAdapter",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "router",
-        "type": "address"
-      },
-      {
-        "internalType": "bytes",
-        "name": "data",
-        "type": "bytes"
-      }
-    ],
-    "name": "initializeRouter",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "key",
-        "type": "bytes32"
-      }
-    ],
-    "name": "isAdapterInitialized",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "key",
-        "type": "bytes32"
-      }
-    ],
-    "name": "isRouterInitialized",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "partner",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_partnerShare",
-        "type": "uint256"
-      },
-      {
-        "internalType": "bool",
-        "name": "_noPositiveSlippage",
-        "type": "bool"
-      },
-      {
-        "internalType": "bool",
-        "name": "_positiveSlippageToUser",
-        "type": "bool"
-      },
-      {
-        "internalType": "uint16",
-        "name": "_feePercent",
-        "type": "uint16"
-      },
-      {
-        "internalType": "string",
-        "name": "partnerId",
-        "type": "string"
-      },
-      {
-        "internalType": "bytes",
-        "name": "_data",
-        "type": "bytes"
-      }
-    ],
-    "name": "registerPartner",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "role",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      }
-    ],
-    "name": "renounceRole",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "role",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      }
-    ],
-    "name": "revokeRole",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address payable",
-        "name": "_feeWallet",
-        "type": "address"
-      }
-    ],
-    "name": "setFeeWallet",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes4",
-        "name": "selector",
-        "type": "bytes4"
-      },
-      {
-        "internalType": "address",
-        "name": "implementation",
-        "type": "address"
-      }
-    ],
-    "name": "setImplementation",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "token",
-        "type": "address"
-      },
-      {
-        "internalType": "address payable",
-        "name": "destination",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "amount",
-        "type": "uint256"
-      }
-    ],
-    "name": "transferTokens",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "stateMutability": "payable",
-    "type": "receive"
-  }
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "adapter",
+                "type": "address"
+            }
+        ],
+        "name": "AdapterInitialized",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "previousAdminRole",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "newAdminRole",
+                "type": "bytes32"
+            }
+        ],
+        "name": "RoleAdminChanged",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            }
+        ],
+        "name": "RoleGranted",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            }
+        ],
+        "name": "RoleRevoked",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "router",
+                "type": "address"
+            }
+        ],
+        "name": "RouterInitialized",
+        "type": "event"
+    },
+    {
+        "stateMutability": "payable",
+        "type": "fallback"
+    },
+    {
+        "inputs": [],
+        "name": "DEFAULT_ADMIN_ROLE",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "ROUTER_ROLE",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "WHITELISTED_ROLE",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "key",
+                "type": "bytes32"
+            }
+        ],
+        "name": "getAdapterData",
+        "outputs": [
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "getFeeWallet",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes4",
+                "name": "selector",
+                "type": "bytes4"
+            }
+        ],
+        "name": "getImplementation",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "partner",
+                "type": "address"
+            }
+        ],
+        "name": "getPartnerFeeStructure",
+        "outputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "uint256",
+                        "name": "partnerShare",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "bool",
+                        "name": "noPositiveSlippage",
+                        "type": "bool"
+                    },
+                    {
+                        "internalType": "bool",
+                        "name": "positiveSlippageToUser",
+                        "type": "bool"
+                    },
+                    {
+                        "internalType": "uint16",
+                        "name": "feePercent",
+                        "type": "uint16"
+                    },
+                    {
+                        "internalType": "string",
+                        "name": "partnerId",
+                        "type": "string"
+                    },
+                    {
+                        "internalType": "bytes",
+                        "name": "data",
+                        "type": "bytes"
+                    }
+                ],
+                "internalType": "struct AugustusStorage.FeeStructure",
+                "name": "",
+                "type": "tuple"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            }
+        ],
+        "name": "getRoleAdmin",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "uint256",
+                "name": "index",
+                "type": "uint256"
+            }
+        ],
+        "name": "getRoleMember",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            }
+        ],
+        "name": "getRoleMemberCount",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "key",
+                "type": "bytes32"
+            }
+        ],
+        "name": "getRouterData",
+        "outputs": [
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "getTokenTransferProxy",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "getVersion",
+        "outputs": [
+            {
+                "internalType": "string",
+                "name": "",
+                "type": "string"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "grantRole",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "hasRole",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "adapter",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "initializeAdapter",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "router",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "initializeRouter",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "key",
+                "type": "bytes32"
+            }
+        ],
+        "name": "isAdapterInitialized",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "key",
+                "type": "bytes32"
+            }
+        ],
+        "name": "isRouterInitialized",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "partner",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "_partnerShare",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bool",
+                "name": "_noPositiveSlippage",
+                "type": "bool"
+            },
+            {
+                "internalType": "bool",
+                "name": "_positiveSlippageToUser",
+                "type": "bool"
+            },
+            {
+                "internalType": "uint16",
+                "name": "_feePercent",
+                "type": "uint16"
+            },
+            {
+                "internalType": "string",
+                "name": "partnerId",
+                "type": "string"
+            },
+            {
+                "internalType": "bytes",
+                "name": "_data",
+                "type": "bytes"
+            }
+        ],
+        "name": "registerPartner",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "renounceRole",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "revokeRole",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address payable",
+                "name": "_feeWallet",
+                "type": "address"
+            }
+        ],
+        "name": "setFeeWallet",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes4",
+                "name": "selector",
+                "type": "bytes4"
+            },
+            {
+                "internalType": "address",
+                "name": "implementation",
+                "type": "address"
+            }
+        ],
+        "name": "setImplementation",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "token",
+                "type": "address"
+            },
+            {
+                "internalType": "address payable",
+                "name": "destination",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "transferTokens",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "stateMutability": "payable",
+        "type": "receive"
+    }
 ]

--- a/base/paraswap/b2c.json
+++ b/base/paraswap/b2c.json
@@ -1,0 +1,45 @@
+{
+  "blockchainName": "base",
+  "chainId": 8453,
+  "contracts": [
+    {
+      "address": "0x59c7c832e96d2568bea6db468c1aadcbbda08a52",
+      "contractName": "AugustusSwapper",
+      "selectors": {
+        "0x2298207a": {
+          "erc20OfInterest": [
+            "data.fromToken",
+            "data.toToken"
+          ],
+          "method": "simpleBuy",
+          "plugin": "Paraswap"
+        },
+        "0x46c67b6d": {
+          "erc20OfInterest": [
+            "data.fromToken",
+            "data.path.0.path.-1.to"
+          ],
+          "method": "megaSwap",
+          "plugin": "Paraswap"
+        },
+        "0x54e3f31b": {
+          "erc20OfInterest": [
+            "data.fromToken",
+            "data.toToken"
+          ],
+          "method": "simpleSwap",
+          "plugin": "Paraswap"
+        },
+        "0xa94e78ef": {
+          "erc20OfInterest": [
+            "data.fromToken",
+            "data.path.-1.to"
+          ],
+          "method": "multiSwap",
+          "plugin": "Paraswap"
+        }
+      }
+    }
+  ],
+  "name": "Paraswap"
+}

--- a/base/paraswap/b2c.json
+++ b/base/paraswap/b2c.json
@@ -1,45 +1,45 @@
 {
-  "blockchainName": "base",
-  "chainId": 8453,
-  "contracts": [
-    {
-      "address": "0x59c7c832e96d2568bea6db468c1aadcbbda08a52",
-      "contractName": "AugustusSwapper",
-      "selectors": {
-        "0x2298207a": {
-          "erc20OfInterest": [
-            "data.fromToken",
-            "data.toToken"
-          ],
-          "method": "simpleBuy",
-          "plugin": "Paraswap"
-        },
-        "0x46c67b6d": {
-          "erc20OfInterest": [
-            "data.fromToken",
-            "data.path.0.path.-1.to"
-          ],
-          "method": "megaSwap",
-          "plugin": "Paraswap"
-        },
-        "0x54e3f31b": {
-          "erc20OfInterest": [
-            "data.fromToken",
-            "data.toToken"
-          ],
-          "method": "simpleSwap",
-          "plugin": "Paraswap"
-        },
-        "0xa94e78ef": {
-          "erc20OfInterest": [
-            "data.fromToken",
-            "data.path.-1.to"
-          ],
-          "method": "multiSwap",
-          "plugin": "Paraswap"
+    "blockchainName": "base",
+    "chainId": 8453,
+    "contracts": [
+        {
+            "address": "0x59c7c832e96d2568bea6db468c1aadcbbda08a52",
+            "contractName": "AugustusSwapper",
+            "selectors": {
+                "0x2298207a": {
+                    "erc20OfInterest": [
+                        "data.fromToken",
+                        "data.toToken"
+                    ],
+                    "method": "simpleBuy",
+                    "plugin": "Paraswap"
+                },
+                "0x46c67b6d": {
+                    "erc20OfInterest": [
+                        "data.fromToken",
+                        "data.path.0.path.-1.to"
+                    ],
+                    "method": "megaSwap",
+                    "plugin": "Paraswap"
+                },
+                "0x54e3f31b": {
+                    "erc20OfInterest": [
+                        "data.fromToken",
+                        "data.toToken"
+                    ],
+                    "method": "simpleSwap",
+                    "plugin": "Paraswap"
+                },
+                "0xa94e78ef": {
+                    "erc20OfInterest": [
+                        "data.fromToken",
+                        "data.path.-1.to"
+                    ],
+                    "method": "multiSwap",
+                    "plugin": "Paraswap"
+                }
+            }
         }
-      }
-    }
-  ],
-  "name": "Paraswap"
+    ],
+    "name": "Paraswap"
 }

--- a/base/paraswap/eip712.json
+++ b/base/paraswap/eip712.json
@@ -1,0 +1,215 @@
+{
+    "blockchainName": "base",
+    "chainId": 8453,
+    "contracts": [
+        {
+            "address": "0xa003dfba51c9e1e56c67ae445b852bded7ac5eed",
+            "contractName": "AugustusRFQ",
+            "messages": [
+                {
+                    "mapper": {
+                        "fields": [
+                            {
+                                "label": "Nonce and metadata",
+                                "path": "nonceAndMeta"
+                            },
+                            {
+                                "label": "Expiration time",
+                                "path": "expiry"
+                            },
+                            {
+                                "label": "Maker asset address",
+                                "path": "makerAsset"
+                            },
+                            {
+                                "label": "Taker asset address",
+                                "path": "takerAsset"
+                            },
+                            {
+                                "label": "Maker address",
+                                "path": "maker"
+                            },
+                            {
+                                "label": "Taker address",
+                                "path": "taker"
+                            },
+                            {
+                                "label": "Maker amount",
+                                "path": "makerAmount"
+                            },
+                            {
+                                "label": "Taker amount",
+                                "path": "takerAmount"
+                            }
+                        ],
+                        "label": "AugustusRFQ ERC20 order"
+                    },
+                    "schema": {
+                        "EIP712Domain": [
+                            {
+                                "name": "name",
+                                "type": "string"
+                            },
+                            {
+                                "name": "version",
+                                "type": "string"
+                            },
+                            {
+                                "name": "chainId",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "verifyingContract",
+                                "type": "address"
+                            }
+                        ],
+                        "Order": [
+                            {
+                                "name": "nonceAndMeta",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "expiry",
+                                "type": "uint128"
+                            },
+                            {
+                                "name": "makerAsset",
+                                "type": "address"
+                            },
+                            {
+                                "name": "takerAsset",
+                                "type": "address"
+                            },
+                            {
+                                "name": "maker",
+                                "type": "address"
+                            },
+                            {
+                                "name": "taker",
+                                "type": "address"
+                            },
+                            {
+                                "name": "makerAmount",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "takerAmount",
+                                "type": "uint256"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "mapper": {
+                        "fields": [
+                            {
+                                "label": "Nonce and metadata",
+                                "path": "nonceAndMeta"
+                            },
+                            {
+                                "label": "Expiration time",
+                                "path": "expiry"
+                            },
+                            {
+                                "label": "Maker asset encoded",
+                                "path": "makerAsset"
+                            },
+                            {
+                                "label": "Maker asset NFT ID",
+                                "path": "makerAssetId"
+                            },
+                            {
+                                "label": "Taker asset encoded",
+                                "path": "takerAsset"
+                            },
+                            {
+                                "label": "Taker asset NFT ID",
+                                "path": "takerAssetId"
+                            },
+                            {
+                                "label": "Maker address",
+                                "path": "maker"
+                            },
+                            {
+                                "label": "Taker address",
+                                "path": "taker"
+                            },
+                            {
+                                "label": "Maker amount",
+                                "path": "makerAmount"
+                            },
+                            {
+                                "label": "Taker amount",
+                                "path": "takerAmount"
+                            }
+                        ],
+                        "label": "AugustusRFQ NFT order"
+                    },
+                    "schema": {
+                        "EIP712Domain": [
+                            {
+                                "name": "name",
+                                "type": "string"
+                            },
+                            {
+                                "name": "version",
+                                "type": "string"
+                            },
+                            {
+                                "name": "chainId",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "verifyingContract",
+                                "type": "address"
+                            }
+                        ],
+                        "OrderNFT": [
+                            {
+                                "name": "nonceAndMeta",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "expiry",
+                                "type": "uint128"
+                            },
+                            {
+                                "name": "makerAsset",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "makerAssetId",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "takerAsset",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "takerAssetId",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "maker",
+                                "type": "address"
+                            },
+                            {
+                                "name": "taker",
+                                "type": "address"
+                            },
+                            {
+                                "name": "makerAmount",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "takerAmount",
+                                "type": "uint256"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    ],
+    "name": "ParaSwap"
+}


### PR DESCRIPTION
#### 1inch
- https://basescan.org/address/0x1111111254eeb25477b68fb85ed929f73a960582
- Limit Order Protocol is not deployed on Base: https://github.com/1inch/limit-order-protocol/tree/master/deployments/base
- Plugin reference: https://github.com/LedgerHQ/app-plugin-1inch/blob/develop/src/contract.c

#### Paraswap
- AugustusSwapper: https://basescan.org/address/0x59c7c832e96d2568bea6db468c1aadcbbda08a52
	- https://basescan.org/address/0x50731c00e38eb1517ed08b7d9d9Fe86bF790De4E
	- https://basescan.org/address/0xD5717e078bFcCfCF8db4D8C280aC2e78f57159fA 
- AugustusRFQ: https://basescan.org/address/0xa003dfba51c9e1e56c67ae445b852bded7ac5eed
- Plugin reference: https://github.com/LedgerHQ/app-plugin-paraswap/blob/develop/src/contract.c