### PR TITLE
feat: added support for StakeKit smart contract on BSC

### DIFF
--- a/bsc/stakekit/abis/0x0000000000000000000000000000000000002002.abi.json
+++ b/bsc/stakekit/abis/0x0000000000000000000000000000000000002002.abi.json
@@ -1,0 +1,1812 @@
+[
+    {
+        "inputs": [],
+        "name": "AlreadyPaused",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "AlreadySlashed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ConsensusAddressExpired",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "DelegationAmountTooSmall",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "DuplicateConsensusAddress",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "DuplicateMoniker",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "DuplicateVoteAddress",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InBlackList",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidCommission",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidConsensusAddress",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidMoniker",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidRequest",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidSynPackage",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "string",
+                "name": "key",
+                "type": "string"
+            },
+            {
+                "internalType": "bytes",
+                "name": "value",
+                "type": "bytes"
+            }
+        ],
+        "name": "InvalidValue",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "InvalidVoteAddress",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "JailTimeNotExpired",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "NoMoreFelonyAllowed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "NotPaused",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "OnlyCoinbase",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "OnlyProtector",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "OnlySelfDelegation",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "systemContract",
+                "type": "address"
+            }
+        ],
+        "name": "OnlySystemContract",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "OnlyZeroGasPrice",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "SameValidator",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "SelfDelegationNotEnough",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "TransferFailed",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "string",
+                "name": "key",
+                "type": "string"
+            },
+            {
+                "internalType": "bytes",
+                "name": "value",
+                "type": "bytes"
+            }
+        ],
+        "name": "UnknownParam",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "UpdateTooFrequently",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ValidatorExisted",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ValidatorNotExisted",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ValidatorNotJailed",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "VoteAddressExpired",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ZeroShares",
+        "type": "error"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "target",
+                "type": "address"
+            }
+        ],
+        "name": "BlackListed",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "operatorAddress",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "delegator",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "bnbAmount",
+                "type": "uint256"
+            }
+        ],
+        "name": "Claimed",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "operatorAddress",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint64",
+                "name": "newCommissionRate",
+                "type": "uint64"
+            }
+        ],
+        "name": "CommissionRateEdited",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "operatorAddress",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "newConsensusAddress",
+                "type": "address"
+            }
+        ],
+        "name": "ConsensusAddressEdited",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "operatorAddress",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "delegator",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "shares",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "bnbAmount",
+                "type": "uint256"
+            }
+        ],
+        "name": "Delegated",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "operatorAddress",
+                "type": "address"
+            }
+        ],
+        "name": "DescriptionEdited",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint8",
+                "name": "version",
+                "type": "uint8"
+            }
+        ],
+        "name": "Initialized",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "operatorAddress",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "delegator",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "bnbAmount",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "enum StakeHub.StakeMigrationRespCode",
+                "name": "respCode",
+                "type": "uint8"
+            }
+        ],
+        "name": "MigrateFailed",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "operatorAddress",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "delegator",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "shares",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "bnbAmount",
+                "type": "uint256"
+            }
+        ],
+        "name": "MigrateSuccess",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "string",
+                "name": "key",
+                "type": "string"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes",
+                "name": "value",
+                "type": "bytes"
+            }
+        ],
+        "name": "ParamChange",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [],
+        "name": "Paused",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "oldProtector",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "newProtector",
+                "type": "address"
+            }
+        ],
+        "name": "ProtectorChanged",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "srcValidator",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "dstValidator",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "delegator",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "oldShares",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "newShares",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "bnbAmount",
+                "type": "uint256"
+            }
+        ],
+        "name": "Redelegated",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [],
+        "name": "Resumed",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "operatorAddress",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes",
+                "name": "failReason",
+                "type": "bytes"
+            }
+        ],
+        "name": "RewardDistributeFailed",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "operatorAddress",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "reward",
+                "type": "uint256"
+            }
+        ],
+        "name": "RewardDistributed",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "operatorAddress",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "creditContract",
+                "type": "address"
+            }
+        ],
+        "name": "StakeCreditInitialized",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "target",
+                "type": "address"
+            }
+        ],
+        "name": "UnBlackListed",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "operatorAddress",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "delegator",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "shares",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "bnbAmount",
+                "type": "uint256"
+            }
+        ],
+        "name": "Undelegated",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint8",
+                "name": "channelId",
+                "type": "uint8"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes",
+                "name": "msgBytes",
+                "type": "bytes"
+            }
+        ],
+        "name": "UnexpectedPackage",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "consensusAddress",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "operatorAddress",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "creditContract",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes",
+                "name": "voteAddress",
+                "type": "bytes"
+            }
+        ],
+        "name": "ValidatorCreated",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "operatorAddress",
+                "type": "address"
+            }
+        ],
+        "name": "ValidatorEmptyJailed",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "operatorAddress",
+                "type": "address"
+            }
+        ],
+        "name": "ValidatorJailed",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "operatorAddress",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "jailUntil",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "slashAmount",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "enum StakeHub.SlashType",
+                "name": "slashType",
+                "type": "uint8"
+            }
+        ],
+        "name": "ValidatorSlashed",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "operatorAddress",
+                "type": "address"
+            }
+        ],
+        "name": "ValidatorUnjailed",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "operatorAddress",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes",
+                "name": "newVoteAddress",
+                "type": "bytes"
+            }
+        ],
+        "name": "VoteAddressEdited",
+        "type": "event"
+    },
+    {
+        "inputs": [],
+        "name": "BC_FUSION_CHANNELID",
+        "outputs": [
+            {
+                "internalType": "uint8",
+                "name": "",
+                "type": "uint8"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "BREATHE_BLOCK_INTERVAL",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "DEAD_ADDRESS",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "LOCK_AMOUNT",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "REDELEGATE_FEE_RATE_BASE",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "STAKING_CHANNELID",
+        "outputs": [
+            {
+                "internalType": "uint8",
+                "name": "",
+                "type": "uint8"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "addToBlackList",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "blackList",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "operatorAddress",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "requestNumber",
+                "type": "uint256"
+            }
+        ],
+        "name": "claim",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address[]",
+                "name": "operatorAddresses",
+                "type": "address[]"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "requestNumbers",
+                "type": "uint256[]"
+            }
+        ],
+        "name": "claimBatch",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "consensusExpiration",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "consensusToOperator",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "consensusAddress",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes",
+                "name": "voteAddress",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes",
+                "name": "blsProof",
+                "type": "bytes"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "uint64",
+                        "name": "rate",
+                        "type": "uint64"
+                    },
+                    {
+                        "internalType": "uint64",
+                        "name": "maxRate",
+                        "type": "uint64"
+                    },
+                    {
+                        "internalType": "uint64",
+                        "name": "maxChangeRate",
+                        "type": "uint64"
+                    }
+                ],
+                "internalType": "struct StakeHub.Commission",
+                "name": "commission",
+                "type": "tuple"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "string",
+                        "name": "moniker",
+                        "type": "string"
+                    },
+                    {
+                        "internalType": "string",
+                        "name": "identity",
+                        "type": "string"
+                    },
+                    {
+                        "internalType": "string",
+                        "name": "website",
+                        "type": "string"
+                    },
+                    {
+                        "internalType": "string",
+                        "name": "details",
+                        "type": "string"
+                    }
+                ],
+                "internalType": "struct StakeHub.Description",
+                "name": "description",
+                "type": "tuple"
+            }
+        ],
+        "name": "createValidator",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "operatorAddress",
+                "type": "address"
+            },
+            {
+                "internalType": "bool",
+                "name": "delegateVotePower",
+                "type": "bool"
+            }
+        ],
+        "name": "delegate",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "consensusAddress",
+                "type": "address"
+            }
+        ],
+        "name": "distributeReward",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "consensusAddress",
+                "type": "address"
+            }
+        ],
+        "name": "doubleSignSlash",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "downtimeJailTime",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "consensusAddress",
+                "type": "address"
+            }
+        ],
+        "name": "downtimeSlash",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "downtimeSlashAmount",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint64",
+                "name": "commissionRate",
+                "type": "uint64"
+            }
+        ],
+        "name": "editCommissionRate",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "newConsensusAddress",
+                "type": "address"
+            }
+        ],
+        "name": "editConsensusAddress",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "string",
+                        "name": "moniker",
+                        "type": "string"
+                    },
+                    {
+                        "internalType": "string",
+                        "name": "identity",
+                        "type": "string"
+                    },
+                    {
+                        "internalType": "string",
+                        "name": "website",
+                        "type": "string"
+                    },
+                    {
+                        "internalType": "string",
+                        "name": "details",
+                        "type": "string"
+                    }
+                ],
+                "internalType": "struct StakeHub.Description",
+                "name": "description",
+                "type": "tuple"
+            }
+        ],
+        "name": "editDescription",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "newVoteAddress",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes",
+                "name": "blsProof",
+                "type": "bytes"
+            }
+        ],
+        "name": "editVoteAddress",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "felonyJailTime",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "felonySlashAmount",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "operatorAddress",
+                "type": "address"
+            }
+        ],
+        "name": "getValidatorBasicInfo",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "createdTime",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bool",
+                "name": "jailed",
+                "type": "bool"
+            },
+            {
+                "internalType": "uint256",
+                "name": "jailUntil",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "operatorAddress",
+                "type": "address"
+            }
+        ],
+        "name": "getValidatorCommission",
+        "outputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "uint64",
+                        "name": "rate",
+                        "type": "uint64"
+                    },
+                    {
+                        "internalType": "uint64",
+                        "name": "maxRate",
+                        "type": "uint64"
+                    },
+                    {
+                        "internalType": "uint64",
+                        "name": "maxChangeRate",
+                        "type": "uint64"
+                    }
+                ],
+                "internalType": "struct StakeHub.Commission",
+                "name": "",
+                "type": "tuple"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "operatorAddress",
+                "type": "address"
+            }
+        ],
+        "name": "getValidatorConsensusAddress",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "consensusAddress",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "operatorAddress",
+                "type": "address"
+            }
+        ],
+        "name": "getValidatorCreditContract",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "creditContract",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "operatorAddress",
+                "type": "address"
+            }
+        ],
+        "name": "getValidatorDescription",
+        "outputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "string",
+                        "name": "moniker",
+                        "type": "string"
+                    },
+                    {
+                        "internalType": "string",
+                        "name": "identity",
+                        "type": "string"
+                    },
+                    {
+                        "internalType": "string",
+                        "name": "website",
+                        "type": "string"
+                    },
+                    {
+                        "internalType": "string",
+                        "name": "details",
+                        "type": "string"
+                    }
+                ],
+                "internalType": "struct StakeHub.Description",
+                "name": "",
+                "type": "tuple"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "offset",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "limit",
+                "type": "uint256"
+            }
+        ],
+        "name": "getValidatorElectionInfo",
+        "outputs": [
+            {
+                "internalType": "address[]",
+                "name": "consensusAddrs",
+                "type": "address[]"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "votingPowers",
+                "type": "uint256[]"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "voteAddrs",
+                "type": "bytes[]"
+            },
+            {
+                "internalType": "uint256",
+                "name": "totalLength",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "operatorAddress",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "index",
+                "type": "uint256"
+            }
+        ],
+        "name": "getValidatorRewardRecord",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "operatorAddress",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "index",
+                "type": "uint256"
+            }
+        ],
+        "name": "getValidatorTotalPooledBNBRecord",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "operatorAddress",
+                "type": "address"
+            }
+        ],
+        "name": "getValidatorVoteAddress",
+        "outputs": [
+            {
+                "internalType": "bytes",
+                "name": "voteAddress",
+                "type": "bytes"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "offset",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "limit",
+                "type": "uint256"
+            }
+        ],
+        "name": "getValidators",
+        "outputs": [
+            {
+                "internalType": "address[]",
+                "name": "operatorAddrs",
+                "type": "address[]"
+            },
+            {
+                "internalType": "address[]",
+                "name": "creditAddrs",
+                "type": "address[]"
+            },
+            {
+                "internalType": "uint256",
+                "name": "totalLength",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint8",
+                "name": "channelId",
+                "type": "uint8"
+            },
+            {
+                "internalType": "bytes",
+                "name": "msgBytes",
+                "type": "bytes"
+            }
+        ],
+        "name": "handleAckPackage",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint8",
+                "name": "channelId",
+                "type": "uint8"
+            },
+            {
+                "internalType": "bytes",
+                "name": "msgBytes",
+                "type": "bytes"
+            }
+        ],
+        "name": "handleFailAckPackage",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint8",
+                "name": "",
+                "type": "uint8"
+            },
+            {
+                "internalType": "bytes",
+                "name": "msgBytes",
+                "type": "bytes"
+            }
+        ],
+        "name": "handleSynPackage",
+        "outputs": [
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "initialize",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "isPaused",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "voteAddress",
+                "type": "bytes"
+            }
+        ],
+        "name": "maliciousVoteSlash",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "maxElectedValidators",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "maxFelonyBetweenBreatheBlock",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "minDelegationBNBChange",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "minSelfDelegationBNB",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "numOfJailed",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "pause",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "srcValidator",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "dstValidator",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "shares",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bool",
+                "name": "delegateVotePower",
+                "type": "bool"
+            }
+        ],
+        "name": "redelegate",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "redelegateFeeRate",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "removeFromBlackList",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "resume",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address[]",
+                "name": "operatorAddresses",
+                "type": "address[]"
+            },
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "syncGovToken",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "transferGasLimit",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "unbondPeriod",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "operatorAddress",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "shares",
+                "type": "uint256"
+            }
+        ],
+        "name": "undelegate",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "operatorAddress",
+                "type": "address"
+            }
+        ],
+        "name": "unjail",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "string",
+                "name": "key",
+                "type": "string"
+            },
+            {
+                "internalType": "bytes",
+                "name": "value",
+                "type": "bytes"
+            }
+        ],
+        "name": "updateParam",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "name": "voteExpiration",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "name": "voteToOperator",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "stateMutability": "payable",
+        "type": "receive"
+    }
+]

--- a/bsc/stakekit/b2c.json
+++ b/bsc/stakekit/b2c.json
@@ -12,6 +12,32 @@
                     "plugin": "StakeKit"
                 }
             }
+        },
+        {
+            "address": "0x0000000000000000000000000000000000002002",
+            "contractName": "StakeHub",
+            "selectors": {
+                "0x4d99dd16": {
+                    "erc20OfInterest": [],
+                    "method": "undelegate",
+                    "plugin": "StakeKit"
+                },
+                "0x59491871": {
+                    "erc20OfInterest": [],
+                    "method": "redelegate",
+                    "plugin": "StakeKit"
+                },
+                "0x982ef0a7": {
+                    "erc20OfInterest": [],
+                    "method": "delegate",
+                    "plugin": "StakeKit"
+                },
+                "0xaad3ec96": {
+                    "erc20OfInterest": [],
+                    "method": "claim",
+                    "plugin": "StakeKit"
+                }
+            }
         }
     ],
     "name": "StakeKit"


### PR DESCRIPTION
Added support for the StakeHub smart contract on BSC network.
Methods supported:
- undelegate
- redelegate
- delegate
- claim