### PR TITLE
ci: Add setuptools to pip installation command

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -33,7 +33,7 @@ jobs:
           cache: 'pipenv'
 
       - name: Install pipenv
-        run: pip install -U pip pipenv wheel
+        run: pip install -U pip pipenv wheel setuptools
 
       - name: Install python dependencies
         env:


### PR DESCRIPTION
https://stackoverflow.com/questions/7446187/no-module-named-pkg-resources

